### PR TITLE
Address issues #1 and #3: Lunet badge + startup verbosity

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # lunet-mcp-sse
 
+[![Lunet v0.1.2](https://img.shields.io/badge/Lunet-v0.1.2-blue?logo=lua&logoColor=white)](https://github.com/lua-lunet/lunet/releases/tag/v0.1.2)
+
 A minimal MCP (Model Context Protocol) server demonstrating Tavily web search via SSE transport, built on the [Lunet](https://github.com/lua-lunet/lunet) framework.
 
 ## Why Lunet?
@@ -244,6 +246,10 @@ The server includes a zero-cost tracing system that has **no overhead when disab
 ```bash
 # No tracing (production, zero overhead)
 ./run.sh
+
+# Verbose startup - show server banner
+./run.sh -v
+# or: ./run.sh --verbose
 
 # Info level - see sessions and tool calls
 MCP_TRACE=info ./run.sh

--- a/app/main.lua
+++ b/app/main.lua
@@ -21,9 +21,21 @@
 -- Tracing:
 --   MCP_TRACE=info make run
 --   MCP_TRACE=debug make run
+--
+-- Verbose startup:
+--   ./bin/lunet -v app/main.lua   # or --verbose
 
 io.stdout:setvbuf('no')
 io.stderr:setvbuf('no')
+
+-- Parse -v/--verbose for startup logging
+local VERBOSE = false
+for i = 1, #arg do
+    if arg[i] == "-v" or arg[i] == "--verbose" then
+        VERBOSE = true
+        break
+    end
+end
 
 local lunet = require("lunet")
 local socket = require("lunet.socket")
@@ -58,7 +70,9 @@ end
 load_env_file(".env")
 local TAVILY_API_KEY = getenv("TAVILY_API_KEY")
 if not TAVILY_API_KEY then
-    print("WARNING: TAVILY_API_KEY not set. Tavily search will fail.")
+    if VERBOSE then
+        print("WARNING: TAVILY_API_KEY not set. Tavily search will fail.")
+    end
     trace.warn("CONFIG", "TAVILY_API_KEY not set")
 end
 
@@ -657,27 +671,29 @@ lunet.spawn(function()
     local listener, err = socket.listen("tcp", host, port)
     if not listener then
         trace.error("SERVER", "Cannot listen on port %d: %s", port, err or "unknown")
-        print("FATAL: Cannot listen: " .. (err or "unknown"))
+        io.stderr:write("FATAL: Cannot listen: " .. (err or "unknown") .. "\n")
         return
     end
 
     trace.info("SERVER", "Starting on port %d", port)
-    print("MCP-SSE Tavily Demo Server")
-    print("==========================")
-    print("Protocol: MCP " .. MCP_VERSION)
-    print("Server:   " .. SERVER_NAME .. " v" .. SERVER_VERSION)
-    print("Port:     http://" .. host .. ":" .. port)
-    print("")
-    print("Endpoints:")
-    print("  GET  /       -> Server info")
-    print("  GET  /sse    -> SSE stream (creates session)")
-    print("  POST /message?session=<id> -> Send JSON-RPC message")
-    print("")
-    print("Tools: tavily-search")
-    print("")
-    print("Test:")
-    print("  curl http://localhost:" .. port .. "/")
-    print("  curl -N http://localhost:" .. port .. "/sse")
+    if VERBOSE then
+        print("MCP-SSE Tavily Demo Server")
+        print("==========================")
+        print("Protocol: MCP " .. MCP_VERSION)
+        print("Server:   " .. SERVER_NAME .. " v" .. SERVER_VERSION)
+        print("Port:     http://" .. host .. ":" .. port)
+        print("")
+        print("Endpoints:")
+        print("  GET  /       -> Server info")
+        print("  GET  /sse    -> SSE stream (creates session)")
+        print("  POST /message?session=<id> -> Send JSON-RPC message")
+        print("")
+        print("Tools: tavily-search")
+        print("")
+        print("Test:")
+        print("  curl http://localhost:" .. port .. "/")
+        print("  curl -N http://localhost:" .. port .. "/sse")
+    end
 
     while true do
         local client = socket.accept(listener)

--- a/run.sh
+++ b/run.sh
@@ -24,7 +24,7 @@ LUA_CPATH="./lib/?.so;;"
 export LUA_CPATH
 
 if [ -f "$LUNET_BIN" ]; then
-	exec "$LUNET_BIN" app/main.lua
+	exec "$LUNET_BIN" app/main.lua "$@"
 else
 	echo "ERROR: lunet binary not found at $LUNET_BIN"
 	ls -la bin/ 2>/dev/null || true


### PR DESCRIPTION
Issue #3: Add Lunet v0.1.2 badge to README header
- Standardizes version visibility across Lunet projects

Issue #1/PR #1: Startup logging verbosity
- Application silent by default (no startup banner)
- Add -v/--verbose flag for verbose startup logging
- TAVILY_API_KEY warning only shown with -v
- FATAL errors always printed to stderr
- run.sh passes args to app (e.g. ./run.sh -v)