### PR TITLE
Upgrade to Lunet v0.2.3 xmake integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -373,12 +373,10 @@ jobs:
 
       - name: Prepare binaries
         run: |
-          mkdir -p bin lib app
-          cp artifacts/amd64/bin/lunet bin/lunet
-          cp artifacts/arm64/bin/lunet bin/lunet
-          cp artifacts/amd64/lib/*.so lib/ 2>/dev/null || true
-          cp -r artifacts/amd64/app/* app/
-          cp artifacts/amd64/run.sh .
+          for arch in amd64 arm64; do
+            mkdir -p "staging/${arch}/bin" "staging/${arch}/lib" "staging/${arch}/app"
+            tar -xzf "artifacts/${arch}/lunet-mcp-sse-linux-${arch}.tar.gz" -C "staging/${arch}"
+          done
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -404,6 +402,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
+          file: Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -419,7 +418,7 @@ jobs:
   nightly:
     name: Nightly Release
     runs-on: ubuntu-latest
-    needs: [build-linux-amd64, build-linux-arm64, build-macos, build-windows, docker]
+    needs: [build-linux-amd64, build-linux-arm64, build-macos, build-windows]
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,22 +16,14 @@ on:
 permissions:
   contents: write
 
-env:
-  LUNET_VERSION: main
-
 jobs:
   build-linux-amd64:
     name: Build Linux amd64
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
-
-      - name: Checkout lunet
-        uses: actions/checkout@v4
         with:
-          repository: lua-lunet/lunet
-          ref: ${{ env.LUNET_VERSION }}
-          path: lunet
+          submodules: recursive
 
       - uses: xmake-io/github-action-setup-xmake@v1
         with:
@@ -43,20 +35,20 @@ jobs:
           sudo apt-get install -y pkg-config libuv1-dev luajit libluajit-5.1-dev
 
       - name: Configure Lunet
-        working-directory: lunet
+        working-directory: deps/lunet
         run: xmake f -m release -y
 
       - name: Build Lunet
-        working-directory: lunet
+        working-directory: deps/lunet
         run: xmake build
 
       - name: Build Lunet SQLite3
-        working-directory: lunet
+        working-directory: deps/lunet
         run: xmake build lunet-sqlite3
 
       - name: Test MCP Server
         run: |
-          LUNET_BIN=$(find lunet/build -name 'lunet-run' -type f | head -1)
+          LUNET_BIN=$(find deps/lunet/build -name 'lunet-run' -type f | head -1)
           timeout 5 $LUNET_BIN app/main.lua &
           SERVER_PID=$!
           sleep 2
@@ -71,9 +63,9 @@ jobs:
           mkdir -p dist/app
           mkdir -p dist/test
 
-          LUNET_BIN=$(find lunet/build -name 'lunet-run' -type f | head -1)
-          LUNET_SO=$(find lunet/build -name 'lunet.so' -type f | head -1)
-          SQLITE_SO=$(find lunet/build -name 'sqlite3.so' -type f | head -1)
+          LUNET_BIN=$(find deps/lunet/build -name 'lunet-run' -type f | head -1)
+          LUNET_SO=$(find deps/lunet/build -name 'lunet.so' -type f | head -1)
+          SQLITE_SO=$(find deps/lunet/build -name 'sqlite3.so' -type f | head -1)
 
           cp "$LUNET_BIN" dist/bin/lunet
           [ -f "$LUNET_SO" ] && cp "$LUNET_SO" dist/lib/ || true
@@ -106,13 +98,8 @@ jobs:
     runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4
-
-      - name: Checkout lunet
-        uses: actions/checkout@v4
         with:
-          repository: lua-lunet/lunet
-          ref: ${{ env.LUNET_VERSION }}
-          path: lunet
+          submodules: recursive
 
       - uses: xmake-io/github-action-setup-xmake@v1
         with:
@@ -124,20 +111,20 @@ jobs:
           sudo apt-get install -y pkg-config libuv1-dev luajit libluajit-5.1-dev
 
       - name: Configure Lunet
-        working-directory: lunet
+        working-directory: deps/lunet
         run: xmake f -m release -y
 
       - name: Build Lunet
-        working-directory: lunet
+        working-directory: deps/lunet
         run: xmake build
 
       - name: Build Lunet SQLite3
-        working-directory: lunet
+        working-directory: deps/lunet
         run: xmake build lunet-sqlite3
 
       - name: Test MCP Server
         run: |
-          LUNET_BIN=$(find lunet/build -name 'lunet-run' -type f | head -1)
+          LUNET_BIN=$(find deps/lunet/build -name 'lunet-run' -type f | head -1)
           timeout 5 $LUNET_BIN app/main.lua &
           SERVER_PID=$!
           sleep 2
@@ -152,9 +139,9 @@ jobs:
           mkdir -p dist/app
           mkdir -p dist/test
 
-          LUNET_BIN=$(find lunet/build -name 'lunet-run' -type f | head -1)
-          LUNET_SO=$(find lunet/build -name 'lunet.so' -type f | head -1)
-          SQLITE_SO=$(find lunet/build -name 'sqlite3.so' -type f | head -1)
+          LUNET_BIN=$(find deps/lunet/build -name 'lunet-run' -type f | head -1)
+          LUNET_SO=$(find deps/lunet/build -name 'lunet.so' -type f | head -1)
+          SQLITE_SO=$(find deps/lunet/build -name 'sqlite3.so' -type f | head -1)
 
           cp "$LUNET_BIN" dist/bin/lunet
           [ -f "$LUNET_SO" ] && cp "$LUNET_SO" dist/lib/ || true
@@ -188,13 +175,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-
-      - name: Checkout lunet
-        uses: actions/checkout@v4
         with:
-          repository: lua-lunet/lunet
-          ref: ${{ env.LUNET_VERSION }}
-          path: lunet
+          submodules: recursive
 
       - uses: xmake-io/github-action-setup-xmake@v1
         with:
@@ -204,20 +186,20 @@ jobs:
         run: brew install pkg-config libuv luajit
 
       - name: Configure Lunet
-        working-directory: lunet
+        working-directory: deps/lunet
         run: xmake f -m release -y
 
       - name: Build Lunet
-        working-directory: lunet
+        working-directory: deps/lunet
         run: xmake build
 
       - name: Build Lunet SQLite3
-        working-directory: lunet
+        working-directory: deps/lunet
         run: xmake build lunet-sqlite3
 
       - name: Test MCP Server
         run: |
-          LUNET_BIN=$(find lunet/build -name 'lunet-run' -type f | head -1)
+          LUNET_BIN=$(find deps/lunet/build -name 'lunet-run' -type f | head -1)
           timeout 5 $LUNET_BIN app/main.lua &
           SERVER_PID=$!
           sleep 2
@@ -232,9 +214,9 @@ jobs:
           mkdir -p dist/app
           mkdir -p dist/test
 
-          LUNET_BIN=$(find lunet/build -name 'lunet-run' -type f | head -1)
-          LUNET_SO=$(find lunet/build -name 'lunet.so' -type f | head -1)
-          SQLITE_SO=$(find lunet/build -name 'sqlite3.so' -type f | head -1)
+          LUNET_BIN=$(find deps/lunet/build -name 'lunet-run' -type f | head -1)
+          LUNET_SO=$(find deps/lunet/build -name 'lunet.so' -type f | head -1)
+          SQLITE_SO=$(find deps/lunet/build -name 'sqlite3.so' -type f | head -1)
 
           cp "$LUNET_BIN" dist/bin/lunet
           [ -f "$LUNET_SO" ] && cp "$LUNET_SO" dist/lib/ || true
@@ -268,13 +250,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-
-      - name: Checkout lunet
-        uses: actions/checkout@v4
         with:
-          repository: lua-lunet/lunet
-          ref: ${{ env.LUNET_VERSION }}
-          path: lunet
+          submodules: recursive
 
       - uses: xmake-io/github-action-setup-xmake@v1
         with:
@@ -289,7 +266,7 @@ jobs:
         run: vcpkg install libuv:x64-windows luajit:x64-windows
 
       - name: Configure Lunet
-        working-directory: lunet
+        working-directory: deps/lunet
         shell: pwsh
         run: |
           $env:VCPKG_ROOT = "${{ github.workspace }}/vcpkg"
@@ -297,11 +274,11 @@ jobs:
           xmake f -m release -y
 
       - name: Build Lunet
-        working-directory: lunet
+        working-directory: deps/lunet
         run: xmake build
 
       - name: Build Lunet SQLite3
-        working-directory: lunet
+        working-directory: deps/lunet
         run: xmake build lunet-sqlite3
 
       - name: Package
@@ -312,9 +289,9 @@ jobs:
           New-Item -ItemType Directory -Force -Path dist/app | Out-Null
           New-Item -ItemType Directory -Force -Path dist/test | Out-Null
 
-          $lunetBin = Get-ChildItem -Path lunet/build -Recurse -Filter "lunet-run.exe" | Select-Object -First 1
-          $lunetDll = Get-ChildItem -Path lunet/build -Recurse -Filter "lunet.dll" | Select-Object -First 1
-          $sqliteDll = Get-ChildItem -Path lunet/build -Recurse -Filter "sqlite3.dll" -ErrorAction SilentlyContinue | Select-Object -First 1
+          $lunetBin = Get-ChildItem -Path deps/lunet/build -Recurse -Filter "lunet-run.exe" | Select-Object -First 1
+          $lunetDll = Get-ChildItem -Path deps/lunet/build -Recurse -Filter "lunet.dll" | Select-Object -First 1
+          $sqliteDll = Get-ChildItem -Path deps/lunet/build -Recurse -Filter "sqlite3.dll" -ErrorAction SilentlyContinue | Select-Object -First 1
 
           Copy-Item $lunetBin.FullName -Destination dist/bin/lunet.exe
           Copy-Item $lunetDll.FullName -Destination dist/lib/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -350,10 +350,75 @@ jobs:
           name: lunet-mcp-sse-windows-amd64
           path: lunet-mcp-sse-windows-amd64.zip
 
+  docker:
+    name: Build Docker Image
+    runs-on: ubuntu-latest
+    needs: [build-linux-amd64, build-linux-arm64]
+    if: github.event_name == 'workflow_dispatch' || (github.ref == 'refs/heads/main' && github.event_name == 'push')
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download amd64 binaries
+        uses: actions/download-artifact@v4
+        with:
+          name: lunet-mcp-sse-linux-amd64
+          path: artifacts/amd64/
+
+      - name: Download arm64 binaries
+        uses: actions/download-artifact@v4
+        with:
+          name: lunet-mcp-sse-linux-arm64
+          path: artifacts/arm64/
+
+      - name: Prepare binaries
+        run: |
+          mkdir -p bin lib app
+          cp artifacts/amd64/bin/lunet bin/lunet
+          cp artifacts/arm64/bin/lunet bin/lunet
+          cp artifacts/amd64/lib/*.so lib/ 2>/dev/null || true
+          cp -r artifacts/amd64/app/* app/
+          cp artifacts/amd64/run.sh .
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=sha
+            type=ref,event=branch
+            type=raw,value=nightly,enable=eq(${{ github.ref }}, 'refs/heads/main')
+
+      - name: Build and push multi-arch Docker
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Show image manifests
+        run: |
+          echo "Image digest:"
+          docker buildx imagetools inspect ghcr.io/lua-lunet/lunet-mcp-sse:nightly 2>/dev/null || echo "Images built successfully"
+
   nightly:
     name: Nightly Release
     runs-on: ubuntu-latest
-    needs: [build-linux-amd64, build-linux-arm64, build-macos, build-windows]
+    needs: [build-linux-amd64, build-linux-arm64, build-macos, build-windows, docker]
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
 
     steps:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "deps/lunet"]
+	path = deps/lunet
+	url = https://github.com/lua-lunet/lunet.git

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,10 @@
+# Agent Notes: lunet-mcp-sse
+
+This repo consumes Lunet via a repo-local git submodule at `deps/lunet`, following the official Lunet xmake integration guide:
+https://github.com/lua-lunet/lunet/blob/main/docs/XMAKE_INTEGRATION.md
+
+Rules
+
+- Do not use or write to a sibling checkout like `../lunet`.
+- If Lunet needs changes: open a PR in `lua-lunet/lunet` first, then bump the `deps/lunet` submodule pointer in a separate PR here.
+- Initialize deps before building: `git submodule update --init --recursive`.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM debian:trixie-slim
+
+ARG TARGETARCH
+
+RUN apt-get update -qq && \
+    apt-get install -y --no-install-recommends \
+      libuv1 libluajit-5.1-2 libcurl4 ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Copy the correct per-arch staging directory
+COPY staging/${TARGETARCH}/ /app/
+
+RUN chmod +x /app/bin/lunet /app/run.sh 2>/dev/null || true
+
+ENV LUA_CPATH="/app/lib/?.so;;"
+
+EXPOSE 8080
+
+ENTRYPOINT ["/app/bin/lunet"]
+CMD ["--dangerously-skip-loopback-restriction", "/app/app/main.lua"]

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,7 @@
 # A demo MCP-SSE server for Tavily search using the Lunet framework.
 # Follows Lunet xmake integration (docs/XMAKE_INTEGRATION.md).
 
-LUNET_DIR ?= ../lunet
-LUNET_REF ?= codex/httpc-libcurl
+LUNET_DIR ?= ./deps/lunet
 LUNET_BIN_HELPER := ./scripts/lunet_bin.sh
 
 # Default timeout for commands (seconds)
@@ -18,37 +17,37 @@ TIMEOUT_CMD := $(shell command -v gtimeout 2>/dev/null || command -v timeout 2>/
 all: help
 
 check-lunet-version:
-	@LUNET_DIR="$(LUNET_DIR)" LUNET_REF="$(LUNET_REF)" $(LUNET_BIN_HELPER) >/dev/null
+	@LUNET_DIR="$(LUNET_DIR)" $(LUNET_BIN_HELPER) >/dev/null
 
 # Build lunet via official xmake flow
 build: check-lunet-version
-	@LUNET_DIR="$(LUNET_DIR)" LUNET_REF="$(LUNET_REF)" $(LUNET_BIN_HELPER) --build >/dev/null
-	@LUNET_BIN=$$(LUNET_DIR="$(LUNET_DIR)" LUNET_REF="$(LUNET_REF)" $(LUNET_BIN_HELPER)); \
+	@LUNET_DIR="$(LUNET_DIR)" $(LUNET_BIN_HELPER) --build >/dev/null
+	@LUNET_BIN=$$(LUNET_DIR="$(LUNET_DIR)" $(LUNET_BIN_HELPER)); \
 	echo "Build complete. Lunet runner: $$LUNET_BIN"
 
 # Run the MCP server (no tracing)
 run: build
-	@LUNET_BIN=$$(LUNET_DIR="$(LUNET_DIR)" LUNET_REF="$(LUNET_REF)" $(LUNET_BIN_HELPER)); \
+	@LUNET_BIN=$$(LUNET_DIR="$(LUNET_DIR)" $(LUNET_BIN_HELPER)); \
 	"$$LUNET_BIN" app/main.lua
 
 # Run with info-level tracing
 run-info: build
-	@LUNET_BIN=$$(LUNET_DIR="$(LUNET_DIR)" LUNET_REF="$(LUNET_REF)" $(LUNET_BIN_HELPER)); \
+	@LUNET_BIN=$$(LUNET_DIR="$(LUNET_DIR)" $(LUNET_BIN_HELPER)); \
 	MCP_TRACE=info "$$LUNET_BIN" app/main.lua
 
 # Run with debug-level tracing
 run-debug: build
-	@LUNET_BIN=$$(LUNET_DIR="$(LUNET_DIR)" LUNET_REF="$(LUNET_REF)" $(LUNET_BIN_HELPER)); \
+	@LUNET_BIN=$$(LUNET_DIR="$(LUNET_DIR)" $(LUNET_BIN_HELPER)); \
 	MCP_TRACE=debug "$$LUNET_BIN" app/main.lua
 
 # Run with full tracing
 run-trace: build
-	@LUNET_BIN=$$(LUNET_DIR="$(LUNET_DIR)" LUNET_REF="$(LUNET_REF)" $(LUNET_BIN_HELPER)); \
+	@LUNET_BIN=$$(LUNET_DIR="$(LUNET_DIR)" $(LUNET_BIN_HELPER)); \
 	MCP_TRACE=trace "$$LUNET_BIN" app/main.lua
 
 # Run with custom port
 run-port: build
-	@LUNET_BIN=$$(LUNET_DIR="$(LUNET_DIR)" LUNET_REF="$(LUNET_REF)" $(LUNET_BIN_HELPER)); \
+	@LUNET_BIN=$$(LUNET_DIR="$(LUNET_DIR)" $(LUNET_BIN_HELPER)); \
 	PORT=$(PORT) "$$LUNET_BIN" app/main.lua
 
 # Test the server (must be running) - with timeout
@@ -77,32 +76,32 @@ stress-shell:
 # Lua stress test (server must be running) - with timeout
 stress: build
 ifneq ($(TIMEOUT_CMD),)
-	@LUNET_BIN=$$(LUNET_DIR="$(LUNET_DIR)" LUNET_REF="$(LUNET_REF)" $(LUNET_BIN_HELPER)); \
+	@LUNET_BIN=$$(LUNET_DIR="$(LUNET_DIR)" $(LUNET_BIN_HELPER)); \
 	$(TIMEOUT_CMD) 60 "$$LUNET_BIN" test/stress_mcp.lua || echo "Stress test timed out or failed"
 else
 	@echo "WARNING: No timeout command available, running without timeout"
-	@LUNET_BIN=$$(LUNET_DIR="$(LUNET_DIR)" LUNET_REF="$(LUNET_REF)" $(LUNET_BIN_HELPER)); \
+	@LUNET_BIN=$$(LUNET_DIR="$(LUNET_DIR)" $(LUNET_BIN_HELPER)); \
 	"$$LUNET_BIN" test/stress_mcp.lua
 endif
 
 # Memory benchmark (starts its own server) - with timeout
 bench: build
 ifneq ($(TIMEOUT_CMD),)
-	@LUNET_BIN=$$(LUNET_DIR="$(LUNET_DIR)" LUNET_REF="$(LUNET_REF)" $(LUNET_BIN_HELPER)); \
+	@LUNET_BIN=$$(LUNET_DIR="$(LUNET_DIR)" $(LUNET_BIN_HELPER)); \
 	$(TIMEOUT_CMD) 30 "$$LUNET_BIN" test/bench_memory.lua || echo "Benchmark timed out or failed"
 else
 	@echo "WARNING: No timeout command available, running without timeout"
-	@LUNET_BIN=$$(LUNET_DIR="$(LUNET_DIR)" LUNET_REF="$(LUNET_REF)" $(LUNET_BIN_HELPER)); \
+	@LUNET_BIN=$$(LUNET_DIR="$(LUNET_DIR)" $(LUNET_BIN_HELPER)); \
 	"$$LUNET_BIN" test/bench_memory.lua
 endif
 
 # Run benchmark with more clients
 bench-heavy: build
 ifneq ($(TIMEOUT_CMD),)
-	@LUNET_BIN=$$(LUNET_DIR="$(LUNET_DIR)" LUNET_REF="$(LUNET_REF)" $(LUNET_BIN_HELPER)); \
+	@LUNET_BIN=$$(LUNET_DIR="$(LUNET_DIR)" $(LUNET_BIN_HELPER)); \
 	BENCH_CLIENTS=100 BENCH_REQUESTS=50 $(TIMEOUT_CMD) 60 "$$LUNET_BIN" test/bench_memory.lua || echo "Heavy benchmark timed out or failed"
 else
-	@LUNET_BIN=$$(LUNET_DIR="$(LUNET_DIR)" LUNET_REF="$(LUNET_REF)" $(LUNET_BIN_HELPER)); \
+	@LUNET_BIN=$$(LUNET_DIR="$(LUNET_DIR)" $(LUNET_BIN_HELPER)); \
 	BENCH_CLIENTS=100 BENCH_REQUESTS=50 "$$LUNET_BIN" test/bench_memory.lua
 endif
 
@@ -124,7 +123,7 @@ help:
 	@echo "A demo MCP-SSE server exposing Tavily search via the Lunet framework."
 	@echo ""
 	@echo "Usage:"
-	@echo "  make build       - Build lunet-run via xmake (Lunet ref $(LUNET_REF))"
+	@echo "  make build       - Build lunet-run via xmake (deps/lunet)"
 	@echo "  make run         - Start the MCP server (port 8080)"
 	@echo "  make run-info    - Start with info-level tracing"
 	@echo "  make run-debug   - Start with debug-level tracing"
@@ -139,8 +138,7 @@ help:
 	@echo "  make clean-all   - Clean all including lunet build"
 	@echo ""
 	@echo "Environment:"
-	@echo "  LUNET_DIR        - Lunet repo path (default: ../lunet)"
-	@echo "  LUNET_REF        - Required Lunet ref/branch/commit (default: codex/httpc-libcurl)"
+	@echo "  LUNET_DIR        - Lunet repo path (default: ./deps/lunet)"
 	@echo "  TAVILY_API_KEY   - Your Tavily API key (in .env file)"
 	@echo "  PORT             - Server port (default 8080)"
 	@echo "  MCP_TRACE        - Trace level: off|error|warn|info|debug|trace"

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 # Follows Lunet xmake integration (docs/XMAKE_INTEGRATION.md).
 
 LUNET_DIR ?= ../lunet
-LUNET_VERSION ?= v0.2.3
+LUNET_REF ?= codex/httpc-libcurl
 LUNET_BIN_HELPER := ./scripts/lunet_bin.sh
 
 # Default timeout for commands (seconds)
@@ -18,37 +18,37 @@ TIMEOUT_CMD := $(shell command -v gtimeout 2>/dev/null || command -v timeout 2>/
 all: help
 
 check-lunet-version:
-	@LUNET_DIR="$(LUNET_DIR)" LUNET_VERSION="$(LUNET_VERSION)" $(LUNET_BIN_HELPER) >/dev/null
+	@LUNET_DIR="$(LUNET_DIR)" LUNET_REF="$(LUNET_REF)" $(LUNET_BIN_HELPER) >/dev/null
 
 # Build lunet via official xmake flow
 build: check-lunet-version
-	@LUNET_DIR="$(LUNET_DIR)" LUNET_VERSION="$(LUNET_VERSION)" $(LUNET_BIN_HELPER) --build >/dev/null
-	@LUNET_BIN=$$(LUNET_DIR="$(LUNET_DIR)" LUNET_VERSION="$(LUNET_VERSION)" $(LUNET_BIN_HELPER)); \
+	@LUNET_DIR="$(LUNET_DIR)" LUNET_REF="$(LUNET_REF)" $(LUNET_BIN_HELPER) --build >/dev/null
+	@LUNET_BIN=$$(LUNET_DIR="$(LUNET_DIR)" LUNET_REF="$(LUNET_REF)" $(LUNET_BIN_HELPER)); \
 	echo "Build complete. Lunet runner: $$LUNET_BIN"
 
 # Run the MCP server (no tracing)
 run: build
-	@LUNET_BIN=$$(LUNET_DIR="$(LUNET_DIR)" LUNET_VERSION="$(LUNET_VERSION)" $(LUNET_BIN_HELPER)); \
+	@LUNET_BIN=$$(LUNET_DIR="$(LUNET_DIR)" LUNET_REF="$(LUNET_REF)" $(LUNET_BIN_HELPER)); \
 	"$$LUNET_BIN" app/main.lua
 
 # Run with info-level tracing
 run-info: build
-	@LUNET_BIN=$$(LUNET_DIR="$(LUNET_DIR)" LUNET_VERSION="$(LUNET_VERSION)" $(LUNET_BIN_HELPER)); \
+	@LUNET_BIN=$$(LUNET_DIR="$(LUNET_DIR)" LUNET_REF="$(LUNET_REF)" $(LUNET_BIN_HELPER)); \
 	MCP_TRACE=info "$$LUNET_BIN" app/main.lua
 
 # Run with debug-level tracing
 run-debug: build
-	@LUNET_BIN=$$(LUNET_DIR="$(LUNET_DIR)" LUNET_VERSION="$(LUNET_VERSION)" $(LUNET_BIN_HELPER)); \
+	@LUNET_BIN=$$(LUNET_DIR="$(LUNET_DIR)" LUNET_REF="$(LUNET_REF)" $(LUNET_BIN_HELPER)); \
 	MCP_TRACE=debug "$$LUNET_BIN" app/main.lua
 
 # Run with full tracing
 run-trace: build
-	@LUNET_BIN=$$(LUNET_DIR="$(LUNET_DIR)" LUNET_VERSION="$(LUNET_VERSION)" $(LUNET_BIN_HELPER)); \
+	@LUNET_BIN=$$(LUNET_DIR="$(LUNET_DIR)" LUNET_REF="$(LUNET_REF)" $(LUNET_BIN_HELPER)); \
 	MCP_TRACE=trace "$$LUNET_BIN" app/main.lua
 
 # Run with custom port
 run-port: build
-	@LUNET_BIN=$$(LUNET_DIR="$(LUNET_DIR)" LUNET_VERSION="$(LUNET_VERSION)" $(LUNET_BIN_HELPER)); \
+	@LUNET_BIN=$$(LUNET_DIR="$(LUNET_DIR)" LUNET_REF="$(LUNET_REF)" $(LUNET_BIN_HELPER)); \
 	PORT=$(PORT) "$$LUNET_BIN" app/main.lua
 
 # Test the server (must be running) - with timeout
@@ -77,32 +77,32 @@ stress-shell:
 # Lua stress test (server must be running) - with timeout
 stress: build
 ifneq ($(TIMEOUT_CMD),)
-	@LUNET_BIN=$$(LUNET_DIR="$(LUNET_DIR)" LUNET_VERSION="$(LUNET_VERSION)" $(LUNET_BIN_HELPER)); \
+	@LUNET_BIN=$$(LUNET_DIR="$(LUNET_DIR)" LUNET_REF="$(LUNET_REF)" $(LUNET_BIN_HELPER)); \
 	$(TIMEOUT_CMD) 60 "$$LUNET_BIN" test/stress_mcp.lua || echo "Stress test timed out or failed"
 else
 	@echo "WARNING: No timeout command available, running without timeout"
-	@LUNET_BIN=$$(LUNET_DIR="$(LUNET_DIR)" LUNET_VERSION="$(LUNET_VERSION)" $(LUNET_BIN_HELPER)); \
+	@LUNET_BIN=$$(LUNET_DIR="$(LUNET_DIR)" LUNET_REF="$(LUNET_REF)" $(LUNET_BIN_HELPER)); \
 	"$$LUNET_BIN" test/stress_mcp.lua
 endif
 
 # Memory benchmark (starts its own server) - with timeout
 bench: build
 ifneq ($(TIMEOUT_CMD),)
-	@LUNET_BIN=$$(LUNET_DIR="$(LUNET_DIR)" LUNET_VERSION="$(LUNET_VERSION)" $(LUNET_BIN_HELPER)); \
+	@LUNET_BIN=$$(LUNET_DIR="$(LUNET_DIR)" LUNET_REF="$(LUNET_REF)" $(LUNET_BIN_HELPER)); \
 	$(TIMEOUT_CMD) 30 "$$LUNET_BIN" test/bench_memory.lua || echo "Benchmark timed out or failed"
 else
 	@echo "WARNING: No timeout command available, running without timeout"
-	@LUNET_BIN=$$(LUNET_DIR="$(LUNET_DIR)" LUNET_VERSION="$(LUNET_VERSION)" $(LUNET_BIN_HELPER)); \
+	@LUNET_BIN=$$(LUNET_DIR="$(LUNET_DIR)" LUNET_REF="$(LUNET_REF)" $(LUNET_BIN_HELPER)); \
 	"$$LUNET_BIN" test/bench_memory.lua
 endif
 
 # Run benchmark with more clients
 bench-heavy: build
 ifneq ($(TIMEOUT_CMD),)
-	@LUNET_BIN=$$(LUNET_DIR="$(LUNET_DIR)" LUNET_VERSION="$(LUNET_VERSION)" $(LUNET_BIN_HELPER)); \
+	@LUNET_BIN=$$(LUNET_DIR="$(LUNET_DIR)" LUNET_REF="$(LUNET_REF)" $(LUNET_BIN_HELPER)); \
 	BENCH_CLIENTS=100 BENCH_REQUESTS=50 $(TIMEOUT_CMD) 60 "$$LUNET_BIN" test/bench_memory.lua || echo "Heavy benchmark timed out or failed"
 else
-	@LUNET_BIN=$$(LUNET_DIR="$(LUNET_DIR)" LUNET_VERSION="$(LUNET_VERSION)" $(LUNET_BIN_HELPER)); \
+	@LUNET_BIN=$$(LUNET_DIR="$(LUNET_DIR)" LUNET_REF="$(LUNET_REF)" $(LUNET_BIN_HELPER)); \
 	BENCH_CLIENTS=100 BENCH_REQUESTS=50 "$$LUNET_BIN" test/bench_memory.lua
 endif
 
@@ -124,7 +124,7 @@ help:
 	@echo "A demo MCP-SSE server exposing Tavily search via the Lunet framework."
 	@echo ""
 	@echo "Usage:"
-	@echo "  make build       - Build lunet-run via xmake (Lunet $(LUNET_VERSION)+)"
+	@echo "  make build       - Build lunet-run via xmake (Lunet ref $(LUNET_REF))"
 	@echo "  make run         - Start the MCP server (port 8080)"
 	@echo "  make run-info    - Start with info-level tracing"
 	@echo "  make run-debug   - Start with debug-level tracing"
@@ -140,7 +140,7 @@ help:
 	@echo ""
 	@echo "Environment:"
 	@echo "  LUNET_DIR        - Lunet repo path (default: ../lunet)"
-	@echo "  LUNET_VERSION    - Required minimum Lunet tag (default: v0.2.3)"
+	@echo "  LUNET_REF        - Required Lunet ref/branch/commit (default: codex/httpc-libcurl)"
 	@echo "  TAVILY_API_KEY   - Your Tavily API key (in .env file)"
 	@echo "  PORT             - Server port (default 8080)"
 	@echo "  MCP_TRACE        - Trace level: off|error|warn|info|debug|trace"

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,11 @@
 # lunet-mcp-sse Makefile
 #
 # A demo MCP-SSE server for Tavily search using the Lunet framework.
-# Assumes lunet is a sibling directory (../lunet)
+# Follows Lunet xmake integration (docs/XMAKE_INTEGRATION.md).
 
-LUNET_DIR := ../lunet
-LUNET_BIN := $(LUNET_DIR)/build/lunet
+LUNET_DIR ?= ../lunet
+LUNET_VERSION ?= v0.2.3
+LUNET_BIN_HELPER := ./scripts/lunet_bin.sh
 
 # Default timeout for commands (seconds)
 TIMEOUT := 10
@@ -12,37 +13,43 @@ TIMEOUT := 10
 # Detect timeout command (GNU coreutils vs BSD)
 TIMEOUT_CMD := $(shell command -v gtimeout 2>/dev/null || command -v timeout 2>/dev/null || echo "")
 
-.PHONY: all build run run-debug run-trace test stress bench bench-shell clean help
+.PHONY: all build check-lunet-version run run-debug run-trace test stress bench bench-shell clean help
 
 all: help
 
-# Build lunet if needed
-$(LUNET_BIN):
-	@echo "Building lunet..."
-	cd $(LUNET_DIR) && $(MAKE) build
+check-lunet-version:
+	@LUNET_DIR="$(LUNET_DIR)" LUNET_VERSION="$(LUNET_VERSION)" $(LUNET_BIN_HELPER) >/dev/null
 
-build: $(LUNET_BIN)
-	@echo "Build complete. Lunet binary: $(LUNET_BIN)"
+# Build lunet via official xmake flow
+build: check-lunet-version
+	@LUNET_DIR="$(LUNET_DIR)" LUNET_VERSION="$(LUNET_VERSION)" $(LUNET_BIN_HELPER) --build >/dev/null
+	@LUNET_BIN=$$(LUNET_DIR="$(LUNET_DIR)" LUNET_VERSION="$(LUNET_VERSION)" $(LUNET_BIN_HELPER)); \
+	echo "Build complete. Lunet runner: $$LUNET_BIN"
 
 # Run the MCP server (no tracing)
-run: $(LUNET_BIN)
-	$(LUNET_BIN) app/main.lua
+run: build
+	@LUNET_BIN=$$(LUNET_DIR="$(LUNET_DIR)" LUNET_VERSION="$(LUNET_VERSION)" $(LUNET_BIN_HELPER)); \
+	"$$LUNET_BIN" app/main.lua
 
 # Run with info-level tracing
-run-info: $(LUNET_BIN)
-	MCP_TRACE=info $(LUNET_BIN) app/main.lua
+run-info: build
+	@LUNET_BIN=$$(LUNET_DIR="$(LUNET_DIR)" LUNET_VERSION="$(LUNET_VERSION)" $(LUNET_BIN_HELPER)); \
+	MCP_TRACE=info "$$LUNET_BIN" app/main.lua
 
 # Run with debug-level tracing
-run-debug: $(LUNET_BIN)
-	MCP_TRACE=debug $(LUNET_BIN) app/main.lua
+run-debug: build
+	@LUNET_BIN=$$(LUNET_DIR="$(LUNET_DIR)" LUNET_VERSION="$(LUNET_VERSION)" $(LUNET_BIN_HELPER)); \
+	MCP_TRACE=debug "$$LUNET_BIN" app/main.lua
 
 # Run with full tracing
-run-trace: $(LUNET_BIN)
-	MCP_TRACE=trace $(LUNET_BIN) app/main.lua
+run-trace: build
+	@LUNET_BIN=$$(LUNET_DIR="$(LUNET_DIR)" LUNET_VERSION="$(LUNET_VERSION)" $(LUNET_BIN_HELPER)); \
+	MCP_TRACE=trace "$$LUNET_BIN" app/main.lua
 
 # Run with custom port
-run-port: $(LUNET_BIN)
-	PORT=$(PORT) $(LUNET_BIN) app/main.lua
+run-port: build
+	@LUNET_BIN=$$(LUNET_DIR="$(LUNET_DIR)" LUNET_VERSION="$(LUNET_VERSION)" $(LUNET_BIN_HELPER)); \
+	PORT=$(PORT) "$$LUNET_BIN" app/main.lua
 
 # Test the server (must be running) - with timeout
 test:
@@ -68,29 +75,35 @@ stress-shell:
 	@echo "Done"
 
 # Lua stress test (server must be running) - with timeout
-stress: $(LUNET_BIN)
+stress: build
 ifneq ($(TIMEOUT_CMD),)
-	$(TIMEOUT_CMD) 60 $(LUNET_BIN) test/stress_mcp.lua || echo "Stress test timed out or failed"
+	@LUNET_BIN=$$(LUNET_DIR="$(LUNET_DIR)" LUNET_VERSION="$(LUNET_VERSION)" $(LUNET_BIN_HELPER)); \
+	$(TIMEOUT_CMD) 60 "$$LUNET_BIN" test/stress_mcp.lua || echo "Stress test timed out or failed"
 else
 	@echo "WARNING: No timeout command available, running without timeout"
-	$(LUNET_BIN) test/stress_mcp.lua
+	@LUNET_BIN=$$(LUNET_DIR="$(LUNET_DIR)" LUNET_VERSION="$(LUNET_VERSION)" $(LUNET_BIN_HELPER)); \
+	"$$LUNET_BIN" test/stress_mcp.lua
 endif
 
 # Memory benchmark (starts its own server) - with timeout
-bench: $(LUNET_BIN)
+bench: build
 ifneq ($(TIMEOUT_CMD),)
-	$(TIMEOUT_CMD) 30 $(LUNET_BIN) test/bench_memory.lua || echo "Benchmark timed out or failed"
+	@LUNET_BIN=$$(LUNET_DIR="$(LUNET_DIR)" LUNET_VERSION="$(LUNET_VERSION)" $(LUNET_BIN_HELPER)); \
+	$(TIMEOUT_CMD) 30 "$$LUNET_BIN" test/bench_memory.lua || echo "Benchmark timed out or failed"
 else
 	@echo "WARNING: No timeout command available, running without timeout"
-	$(LUNET_BIN) test/bench_memory.lua
+	@LUNET_BIN=$$(LUNET_DIR="$(LUNET_DIR)" LUNET_VERSION="$(LUNET_VERSION)" $(LUNET_BIN_HELPER)); \
+	"$$LUNET_BIN" test/bench_memory.lua
 endif
 
 # Run benchmark with more clients
-bench-heavy: $(LUNET_BIN)
+bench-heavy: build
 ifneq ($(TIMEOUT_CMD),)
-	BENCH_CLIENTS=100 BENCH_REQUESTS=50 $(TIMEOUT_CMD) 60 $(LUNET_BIN) test/bench_memory.lua || echo "Heavy benchmark timed out or failed"
+	@LUNET_BIN=$$(LUNET_DIR="$(LUNET_DIR)" LUNET_VERSION="$(LUNET_VERSION)" $(LUNET_BIN_HELPER)); \
+	BENCH_CLIENTS=100 BENCH_REQUESTS=50 $(TIMEOUT_CMD) 60 "$$LUNET_BIN" test/bench_memory.lua || echo "Heavy benchmark timed out or failed"
 else
-	BENCH_CLIENTS=100 BENCH_REQUESTS=50 $(LUNET_BIN) test/bench_memory.lua
+	@LUNET_BIN=$$(LUNET_DIR="$(LUNET_DIR)" LUNET_VERSION="$(LUNET_VERSION)" $(LUNET_BIN_HELPER)); \
+	BENCH_CLIENTS=100 BENCH_REQUESTS=50 "$$LUNET_BIN" test/bench_memory.lua
 endif
 
 # Clean build artifacts
@@ -100,7 +113,7 @@ clean:
 
 # Deep clean (including lunet build)
 clean-all: clean
-	cd $(LUNET_DIR) && $(MAKE) clean 2>/dev/null || true
+	cd $(LUNET_DIR) && xmake clean 2>/dev/null || true
 	@echo "Cleaned all build artifacts"
 
 # Show help
@@ -111,7 +124,7 @@ help:
 	@echo "A demo MCP-SSE server exposing Tavily search via the Lunet framework."
 	@echo ""
 	@echo "Usage:"
-	@echo "  make build       - Build the lunet runtime"
+	@echo "  make build       - Build lunet-run via xmake (Lunet $(LUNET_VERSION)+)"
 	@echo "  make run         - Start the MCP server (port 8080)"
 	@echo "  make run-info    - Start with info-level tracing"
 	@echo "  make run-debug   - Start with debug-level tracing"
@@ -126,6 +139,8 @@ help:
 	@echo "  make clean-all   - Clean all including lunet build"
 	@echo ""
 	@echo "Environment:"
+	@echo "  LUNET_DIR        - Lunet repo path (default: ../lunet)"
+	@echo "  LUNET_VERSION    - Required minimum Lunet tag (default: v0.2.3)"
 	@echo "  TAVILY_API_KEY   - Your Tavily API key (in .env file)"
 	@echo "  PORT             - Server port (default 8080)"
 	@echo "  MCP_TRACE        - Trace level: off|error|warn|info|debug|trace"

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A minimal MCP (Model Context Protocol) server demonstrating Tavily web search via SSE transport, built on the [Lunet](https://github.com/lua-lunet/lunet) framework.
 
+[中文文档](README-CN.md)
+
 ## Why Lunet?
 
 MCP servers are often deployed as sidecar processes or in resource-constrained environments. This implementation prioritizes:
@@ -254,3 +256,7 @@ This tests against:
 ## License
 
 MIT
+
+---
+
+> This project uses [Lunet](https://github.com/lua-lunet/lunet), which is based on [xialeistudio/lunet](https://github.com/xialeistudio/lunet) by [夏磊 (Xia Lei)](https://github.com/xialeistudio). See also his excellent write-up: [Lunet: Design and Implementation of a High-Performance Coroutine Network Library](https://www.ddhigh.com/en/2025/07/12/lunet-high-performance-coroutine-network-library/).

--- a/README.md
+++ b/README.md
@@ -216,9 +216,10 @@ mkdir lua-lunet && cd lua-lunet
 git clone https://github.com/lua-lunet/lunet.git
 git clone https://github.com/lua-lunet/lunet-mcp-sse.git
 
-# Checkout Lunet v0.2.3 and build via xmake (per docs/XMAKE_INTEGRATION.md)
+# Checkout Lunet HTTP client feature branch and build via xmake
 cd lunet
-git checkout v0.2.3
+git checkout codex/httpc-libcurl
+git pull --ff-only
 xmake f -m release --lunet_trace=n --lunet_verbose_trace=n -y
 xmake build lunet-bin
 cd ..
@@ -227,6 +228,9 @@ cd ..
 cd lunet-mcp-sse
 echo "TAVILY_API_KEY=your_key_here" > .env
 make run
+
+# Optional: override Lunet ref/path when needed
+# LUNET_REF=codex/httpc-libcurl LUNET_DIR=../lunet make run
 ```
 
 ## Zero-Cost Tracing

--- a/README.md
+++ b/README.md
@@ -211,26 +211,14 @@ Search the web using Tavily AI search engine.
 ## Building from Source
 
 ```bash
-# Clone the lua-lunet org repos (lunet-mcp-sse requires sibling lunet repo)
-mkdir lua-lunet && cd lua-lunet
-git clone https://github.com/lua-lunet/lunet.git
+# Clone and init submodules
 git clone https://github.com/lua-lunet/lunet-mcp-sse.git
-
-# Checkout Lunet HTTP client feature branch and build via xmake
-cd lunet
-git checkout codex/httpc-libcurl
-git pull --ff-only
-xmake f -m release --lunet_trace=n --lunet_verbose_trace=n -y
-xmake build lunet-bin
-cd ..
+cd lunet-mcp-sse
+git submodule update --init --recursive
 
 # Run
-cd lunet-mcp-sse
 echo "TAVILY_API_KEY=your_key_here" > .env
 make run
-
-# Optional: override Lunet ref/path when needed
-# LUNET_REF=codex/httpc-libcurl LUNET_DIR=../lunet make run
 ```
 
 ## Zero-Cost Tracing

--- a/README.md
+++ b/README.md
@@ -216,8 +216,12 @@ mkdir lua-lunet && cd lua-lunet
 git clone https://github.com/lua-lunet/lunet.git
 git clone https://github.com/lua-lunet/lunet-mcp-sse.git
 
-# Build lunet
-cd lunet && make build && cd ..
+# Checkout Lunet v0.2.3 and build via xmake (per docs/XMAKE_INTEGRATION.md)
+cd lunet
+git checkout v0.2.3
+xmake f -m release --lunet_trace=n --lunet_verbose_trace=n -y
+xmake build lunet-bin
+cd ..
 
 # Run
 cd lunet-mcp-sse

--- a/app/main.lua
+++ b/app/main.lua
@@ -342,7 +342,83 @@ local function shell_escape(s)
     return "'" .. s:gsub("'", "'\\''") .. "'"
 end
 
--- Tavily API call via curl (no TLS in Lunet yet)
+-- Parse URL into components
+local function parse_url(url)
+    local protocol, host, port, path = url:match("^(https?)://([^:/]+):?(%d*)(/?.*)$")
+    if not protocol then
+        return nil, "Invalid URL"
+    end
+    port = tonumber(port) or (protocol == "https" and 443 or 80)
+    path = path == "" and "/" or path
+    return {protocol = protocol, host = host, port = port, path = path}
+end
+
+-- Async HTTP POST using lunet sockets (for HTTP only, not HTTPS)
+local function http_post_async(url, body, headers)
+    local parsed, err = parse_url(url)
+    if not parsed then
+        return nil, err
+    end
+    
+    if parsed.protocol == "https" then
+        -- Fall back to curl for HTTPS (no TLS in lunet)
+        return nil, "HTTPS_FALLBACK"
+    end
+    
+    -- Resolve localhost to 127.0.0.1 (lunet socket doesn't do DNS)
+    local connect_host = parsed.host
+    if connect_host == "localhost" then
+        connect_host = "127.0.0.1"
+    end
+    
+    local client, conn_err = socket.connect(connect_host, parsed.port)
+    if not client then
+        return nil, "Connection failed: " .. (conn_err or "unknown")
+    end
+    
+    -- Build HTTP request
+    local req_lines = {
+        "POST " .. parsed.path .. " HTTP/1.1",
+        "Host: " .. parsed.host .. ":" .. parsed.port,
+        "Content-Type: application/json",
+        "Content-Length: " .. #body,
+        "Connection: close",
+    }
+    
+    for name, value in pairs(headers or {}) do
+        req_lines[#req_lines + 1] = name .. ": " .. value
+    end
+    
+    req_lines[#req_lines + 1] = ""
+    req_lines[#req_lines + 1] = body
+    
+    local request = table.concat(req_lines, "\r\n")
+    
+    local write_err = socket.write(client, request)
+    if write_err then
+        socket.close(client)
+        return nil, "Write failed: " .. tostring(write_err)
+    end
+    
+    -- Read response (lunet socket.read is async)
+    local response = socket.read(client)
+    socket.close(client)
+    
+    if not response then
+        return nil, "No response received"
+    end
+    
+    -- Parse HTTP response
+    local body_start = response:find("\r\n\r\n")
+    if not body_start then
+        return nil, "Invalid HTTP response"
+    end
+    
+    local response_body = response:sub(body_start + 4)
+    return response_body
+end
+
+-- Tavily API call - async for HTTP, curl fallback for HTTPS
 local function tavily_search(query, max_results)
     if not TAVILY_API_KEY then
         return nil, "TAVILY_API_KEY not configured"
@@ -356,18 +432,32 @@ local function tavily_search(query, max_results)
         search_depth = "basic",
     })
 
-    local cmd = "curl -s -X POST 'https://api.tavily.com/search' " ..
-                "-H 'Content-Type: application/json' " ..
-                "-H " .. shell_escape("Authorization: Bearer " .. TAVILY_API_KEY) .. " " ..
-                "-d " .. shell_escape(request_body)
+    local api_url = getenv("TAVILY_API_URL") or "https://api.tavily.com/search"
+    local headers = {
+        ["Authorization"] = "Bearer " .. TAVILY_API_KEY,
+    }
+    
+    -- Try async HTTP first
+    local response, err = http_post_async(api_url, request_body, headers)
+    
+    -- Fall back to curl for HTTPS
+    if err == "HTTPS_FALLBACK" then
+        trace.debug("HTTP", "Using curl fallback for HTTPS")
+        local cmd = "curl -s -X POST '" .. api_url .. "' " ..
+                    "-H 'Content-Type: application/json' " ..
+                    "-H " .. shell_escape("Authorization: Bearer " .. TAVILY_API_KEY) .. " " ..
+                    "-d " .. shell_escape(request_body)
 
-    local handle = io.popen(cmd)
-    if not handle then
-        return nil, "Failed to execute curl"
+        local handle = io.popen(cmd)
+        if not handle then
+            return nil, "Failed to execute curl"
+        end
+
+        response = handle:read("*a")
+        handle:close()
+    elseif not response then
+        return nil, err or "Request failed"
     end
-
-    local response = handle:read("*a")
-    handle:close()
 
     if not response or response == "" then
         return nil, "Empty response from Tavily API"

--- a/app/main.lua
+++ b/app/main.lua
@@ -415,21 +415,40 @@ local function http_post_async(url, body, headers)
         return nil, "Write failed: " .. tostring(write_err)
     end
     
-    -- Read response (lunet socket.read is async)
-    local response = socket.read(client)
+    -- Read response in a loop until EOF (Connection: close)
+    local chunks = {}
+    while true do
+        local chunk = socket.read(client)
+        if not chunk or chunk == "" then break end
+        chunks[#chunks + 1] = chunk
+    end
     socket.close(client)
-    
-    if not response then
+
+    if #chunks == 0 then
         return nil, "No response received"
     end
-    
-    -- Parse HTTP response
+
+    local response = table.concat(chunks)
+
+    -- Parse status line
+    local status_line = response:match("^(.-)\r\n")
+    if not status_line then
+        return nil, "Invalid HTTP response"
+    end
+    local status_code = tonumber(status_line:match("HTTP/%d%.%d (%d+)"))
+
+    -- Parse HTTP response body
     local body_start = response:find("\r\n\r\n")
     if not body_start then
         return nil, "Invalid HTTP response"
     end
-    
+
     local response_body = response:sub(body_start + 4)
+
+    if not status_code or status_code < 200 or status_code >= 300 then
+        return nil, "HTTP " .. tostring(status_code or "???") .. ": " .. response_body:sub(1, 200)
+    end
+
     return response_body
 end
 
@@ -477,7 +496,7 @@ local function tavily_search(query, max_results)
         response = resp.body
     elseif err == "HTTPS_FALLBACK" then
         trace.debug("HTTP", "Using curl fallback for HTTPS")
-        local cmd = "curl -s -X POST '" .. api_url .. "' " ..
+        local cmd = "curl -s -X POST " .. shell_escape(api_url) .. " " ..
                     "-H 'Content-Type: application/json' " ..
                     "-H " .. shell_escape("Authorization: Bearer " .. TAVILY_API_KEY) .. " " ..
                     "-d " .. shell_escape(request_body)

--- a/app/main.lua
+++ b/app/main.lua
@@ -19,8 +19,8 @@
 --   curl -N http://localhost:8080/sse
 --
 -- Tracing:
---   MCP_TRACE=info ./lunet/build/lunet app/main.lua
---   MCP_TRACE=debug ./lunet/build/lunet app/main.lua
+--   MCP_TRACE=info ./lunet/build/<platform>/<arch>/release/lunet-run app/main.lua
+--   MCP_TRACE=debug ./lunet/build/<platform>/<arch>/release/lunet-run app/main.lua
 
 io.stdout:setvbuf('no')
 io.stderr:setvbuf('no')

--- a/app/main.lua
+++ b/app/main.lua
@@ -19,8 +19,8 @@
 --   curl -N http://localhost:8080/sse
 --
 -- Tracing:
---   MCP_TRACE=info ./lunet/build/<platform>/<arch>/release/lunet-run app/main.lua
---   MCP_TRACE=debug ./lunet/build/<platform>/<arch>/release/lunet-run app/main.lua
+--   MCP_TRACE=info ./deps/lunet/build/<platform>/<arch>/release/lunet-run app/main.lua
+--   MCP_TRACE=debug ./deps/lunet/build/<platform>/<arch>/release/lunet-run app/main.lua
 
 io.stdout:setvbuf('no')
 io.stderr:setvbuf('no')
@@ -419,6 +419,8 @@ local function http_post_async(url, body, headers)
 end
 
 -- Tavily API call - async for HTTP, curl fallback for HTTPS
+local httpc_ok, httpc = pcall(require, "lunet.httpc")
+
 local function tavily_search(query, max_results)
     if not TAVILY_API_KEY then
         return nil, "TAVILY_API_KEY not configured"
@@ -440,8 +442,25 @@ local function tavily_search(query, max_results)
     -- Try async HTTP first
     local response, err = http_post_async(api_url, request_body, headers)
     
-    -- Fall back to curl for HTTPS
-    if err == "HTTPS_FALLBACK" then
+    -- HTTPS: prefer native lunet.httpc when available
+    if err == "HTTPS_FALLBACK" and httpc_ok and httpc and type(httpc.request) == "function" then
+        trace.debug("HTTP", "Using lunet.httpc for HTTPS")
+        local resp, herr = httpc.request({
+            url = api_url,
+            method = "POST",
+            headers = {
+                ["Content-Type"] = "application/json",
+                ["Authorization"] = "Bearer " .. TAVILY_API_KEY,
+            },
+            body = request_body,
+            timeout_ms = 30000,
+            max_body_bytes = 5 * 1024 * 1024,
+        })
+        if not resp then
+            return nil, "Tavily HTTPS request failed: " .. (herr or "unknown")
+        end
+        response = resp.body
+    elseif err == "HTTPS_FALLBACK" then
         trace.debug("HTTP", "Using curl fallback for HTTPS")
         local cmd = "curl -s -X POST '" .. api_url .. "' " ..
                     "-H 'Content-Type: application/json' " ..

--- a/benchmark_concurrency.sh
+++ b/benchmark_concurrency.sh
@@ -200,7 +200,7 @@ start_lunet() {
 	if [[ -x ".tmp/macos-app/bin/lunet" ]]; then
 		lunet_bin=".tmp/macos-app/bin/lunet"
 	else
-		lunet_bin=$(LUNET_DIR="${LUNET_DIR:-../lunet}" LUNET_REF="${LUNET_REF:-codex/httpc-libcurl}" ./scripts/lunet_bin.sh --build 2>/dev/null || true)
+		lunet_bin=$(LUNET_DIR="${LUNET_DIR:-./deps/lunet}" ./scripts/lunet_bin.sh --build 2>/dev/null || true)
 	fi
 	if [[ -z "$lunet_bin" ]]; then
 		error "No lunet binary found (.tmp bundle or xmake-built lunet-run)"

--- a/benchmark_concurrency.sh
+++ b/benchmark_concurrency.sh
@@ -195,14 +195,15 @@ start_lunet() {
 
 	cd "$(dirname "$0")"
 
-	# Use the built binary if available
+	# Prefer release bundle binary; otherwise resolve/build lunet-run via xmake.
 	local lunet_bin
 	if [[ -x ".tmp/macos-app/bin/lunet" ]]; then
 		lunet_bin=".tmp/macos-app/bin/lunet"
-	elif [[ -x "./lunet/build/lunet" ]]; then
-		lunet_bin="./lunet/build/lunet"
 	else
-		error "No lunet binary found"
+		lunet_bin=$(LUNET_DIR="${LUNET_DIR:-../lunet}" LUNET_VERSION="${LUNET_VERSION:-v0.2.3}" ./scripts/lunet_bin.sh --build 2>/dev/null || true)
+	fi
+	if [[ -z "$lunet_bin" ]]; then
+		error "No lunet binary found (.tmp bundle or xmake-built lunet-run)"
 		return 1
 	fi
 

--- a/benchmark_concurrency.sh
+++ b/benchmark_concurrency.sh
@@ -200,7 +200,7 @@ start_lunet() {
 	if [[ -x ".tmp/macos-app/bin/lunet" ]]; then
 		lunet_bin=".tmp/macos-app/bin/lunet"
 	else
-		lunet_bin=$(LUNET_DIR="${LUNET_DIR:-../lunet}" LUNET_VERSION="${LUNET_VERSION:-v0.2.3}" ./scripts/lunet_bin.sh --build 2>/dev/null || true)
+		lunet_bin=$(LUNET_DIR="${LUNET_DIR:-../lunet}" LUNET_REF="${LUNET_REF:-codex/httpc-libcurl}" ./scripts/lunet_bin.sh --build 2>/dev/null || true)
 	fi
 	if [[ -z "$lunet_bin" ]]; then
 		error "No lunet binary found (.tmp bundle or xmake-built lunet-run)"

--- a/benchmark_concurrency.sh
+++ b/benchmark_concurrency.sh
@@ -1,0 +1,311 @@
+#!/bin/bash
+# MCP Server Concurrency Benchmark
+#
+# Compares concurrency handling across different MCP implementations:
+# - lunet-mcp-sse (Lua + libuv)
+# - Node.js tavily-mcp
+# - Python FastMCP
+# - Bun tavily-mcp
+#
+# Prerequisites:
+# - hey (HTTP load testing tool): brew install hey
+# - jq
+# - Mock Tavily server running on MOCK_PORT
+#
+# Usage:
+#   ./benchmark_concurrency.sh [implementation] [concurrency] [total_requests]
+
+set -e
+
+# Configuration
+MOCK_PORT=${MOCK_PORT:-19999}
+CONCURRENCY=${2:-50}
+TOTAL_REQUESTS=${3:-500}
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+log() { echo -e "${BLUE}[BENCH]${NC} $*"; }
+success() { echo -e "${GREEN}[BENCH]${NC} $*"; }
+warn() { echo -e "${YELLOW}[BENCH]${NC} $*"; }
+error() { echo -e "${RED}[BENCH]${NC} $*"; }
+
+# Check prerequisites
+check_prereqs() {
+	log "Checking prerequisites..."
+
+	if ! command -v hey &>/dev/null; then
+		error "'hey' not found. Install with: brew install hey"
+		exit 1
+	fi
+
+	if ! command -v jq &>/dev/null; then
+		error "'jq' not found. Install with: brew install jq"
+		exit 1
+	fi
+
+	# Check mock server
+	if ! curl -s "http://localhost:$MOCK_PORT/health" &>/dev/null; then
+		error "Mock Tavily server not running on port $MOCK_PORT"
+		echo "Start it with: nginx -c \"\$(pwd)/.tmp/mock-tavily/nginx.conf\""
+		exit 1
+	fi
+
+	success "Prerequisites OK"
+}
+
+# Get process memory (RSS in KB)
+get_rss() {
+	local pid=$1
+	if [[ "$(uname)" == "Darwin" ]]; then
+		ps -o rss= -p "$pid" 2>/dev/null | tr -d ' '
+	else
+		cat /proc/"$pid"/status 2>/dev/null | grep VmRSS | awk '{print $2}'
+	fi
+}
+
+# Establish SSE session and return session ID
+get_session() {
+	local port=$1
+	local timeout=${2:-2}
+
+	# Connect to SSE endpoint and extract session ID
+	# Use -m for timeout, SSE will hang until timeout but we get first event
+	local response
+	response=$(curl -s -m "$timeout" "http://localhost:$port/sse" 2>&1) || true
+
+	echo "$response" | grep -o 'session=[a-zA-Z0-9]*' | head -1 | cut -d= -f2
+}
+
+# Send MCP initialize
+mcp_initialize() {
+	local port=$1
+	local session=$2
+
+	curl -s -X POST "http://localhost:$port/message?session=$session" \
+		-H "Content-Type: application/json" \
+		-d '{
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": {"name": "benchmark", "version": "1.0"}
+            }
+        }' 2>/dev/null
+}
+
+# Run benchmark against a running MCP server
+benchmark_server() {
+	local name=$1
+	local port=$2
+	local pid=$3
+
+	log "Benchmarking $name on port $port (PID: $pid)"
+
+	# Get baseline memory
+	local mem_before
+	mem_before=$(get_rss "$pid")
+
+	# Get a session
+	local session
+	session=$(get_session "$port")
+	if [[ -z "$session" ]]; then
+		error "Failed to get session from $name"
+		return 1
+	fi
+	log "Session: $session"
+
+	# Initialize the session
+	mcp_initialize "$port" "$session" >/dev/null
+
+	# Prepare the request body (tools/call tavily-search)
+	local body='{"jsonrpc":"2.0","id":999,"method":"tools/call","params":{"name":"tavily-search","arguments":{"query":"test query"}}}'
+
+	# Create temp file for body
+	local body_file
+	body_file=$(mktemp)
+	echo "$body" >"$body_file"
+
+	log "Running: $TOTAL_REQUESTS requests, $CONCURRENCY concurrent"
+
+	# Run hey benchmark
+	local result
+	result=$(hey -n "$TOTAL_REQUESTS" -c "$CONCURRENCY" \
+		-m POST \
+		-H "Content-Type: application/json" \
+		-D "$body_file" \
+		"http://localhost:$port/message?session=$session" 2>&1)
+
+	rm -f "$body_file"
+
+	# Get memory after
+	local mem_after
+	mem_after=$(get_rss "$pid")
+
+	# Parse results from hey output
+	local rps latency_avg latency_p99 errors
+	rps=$(echo "$result" | grep "Requests/sec:" | awk '{print $2}')
+	latency_avg=$(echo "$result" | grep -A1 "Latency" | tail -1 | awk '{print $2}')
+	latency_p99=$(echo "$result" | grep "99% in" | awk '{print $3}')
+
+	# Count errors from Status code distribution
+	local status_200
+	status_200=$(echo "$result" | grep "200" | awk '{print $2}' | head -1)
+	if [[ -n "$status_200" ]]; then
+		errors=$((TOTAL_REQUESTS - status_200))
+	else
+		errors=$(echo "$result" | grep -c "Error\|error" || echo 0)
+	fi
+
+	# Calculate memory delta
+	local mem_delta=0
+	if [[ -n "$mem_before" && -n "$mem_after" ]]; then
+		mem_delta=$((mem_after - mem_before))
+	fi
+
+	# Output results
+	echo ""
+	echo "═══════════════════════════════════════════════════════════"
+	echo "  $name Results"
+	echo "═══════════════════════════════════════════════════════════"
+	echo "  Requests/sec:     $rps"
+	echo "  Avg Latency:      $latency_avg"
+	echo "  P99 Latency:      $latency_p99"
+	echo "  Errors:           $errors"
+	echo "  Memory Before:    ${mem_before:-N/A} KB"
+	echo "  Memory After:     ${mem_after:-N/A} KB"
+	echo "  Memory Delta:     ${mem_delta} KB"
+	echo "═══════════════════════════════════════════════════════════"
+	echo ""
+
+	# Return as JSON for comparison
+	echo "{\"name\":\"$name\",\"rps\":$rps,\"latency_avg\":\"$latency_avg\",\"latency_p99\":\"$latency_p99\",\"errors\":$errors,\"mem_before\":${mem_before:-0},\"mem_after\":${mem_after:-0}}"
+}
+
+# Start lunet server
+start_lunet() {
+	local port=${1:-8080}
+	log "Starting lunet-mcp-sse on port $port..."
+
+	cd "$(dirname "$0")"
+
+	# Use the built binary if available
+	local lunet_bin
+	if [[ -x ".tmp/macos-app/bin/lunet" ]]; then
+		lunet_bin=".tmp/macos-app/bin/lunet"
+	elif [[ -x "./lunet/build/lunet" ]]; then
+		lunet_bin="./lunet/build/lunet"
+	else
+		error "No lunet binary found"
+		return 1
+	fi
+
+	TAVILY_API_URL="http://localhost:$MOCK_PORT/search" \
+		PORT=$port \
+		"$lunet_bin" app/main.lua &
+	local pid=$!
+
+	sleep 1
+
+	if ! kill -0 "$pid" 2>/dev/null; then
+		error "lunet failed to start"
+		return 1
+	fi
+
+	echo "$pid"
+}
+
+# Start Node.js tavily-mcp (requires npx)
+start_nodejs() {
+	local port=${1:-8081}
+	log "Starting Node.js tavily-mcp on port $port..."
+
+	# Check if we have a wrapper that supports mock URL
+	# The official tavily-mcp doesn't support custom API URL, so we need to mock differently
+	# For now, skip if not available
+
+	warn "Node.js tavily-mcp doesn't support custom API URL"
+	warn "Skipping Node.js benchmark (would need to patch the package)"
+	return 1
+}
+
+# Benchmark all implementations
+benchmark_all() {
+	check_prereqs
+
+	local results=()
+
+	# Benchmark lunet
+	log "=== Testing lunet-mcp-sse ==="
+	local lunet_pid
+	lunet_pid=$(start_lunet 8080)
+	if [[ -n "$lunet_pid" ]]; then
+		sleep 2 # Let server stabilize
+		local result
+		result=$(benchmark_server "lunet-mcp-sse" 8080 "$lunet_pid")
+		results+=("$result")
+		kill "$lunet_pid" 2>/dev/null || true
+		wait "$lunet_pid" 2>/dev/null || true
+	fi
+
+	# Summary
+	echo ""
+	echo "╔═══════════════════════════════════════════════════════════╗"
+	echo "║              CONCURRENCY BENCHMARK SUMMARY                ║"
+	echo "╠═══════════════════════════════════════════════════════════╣"
+	echo "║  Concurrency: $CONCURRENCY concurrent connections"
+	echo "║  Total:       $TOTAL_REQUESTS requests"
+	echo "║  Mock Server: localhost:$MOCK_PORT"
+	echo "╚═══════════════════════════════════════════════════════════╝"
+}
+
+# Benchmark a single running server
+benchmark_single() {
+	local port=${1:-8080}
+	local name=${2:-"MCP Server"}
+
+	check_prereqs
+
+	# Find the server PID
+	local pid
+	pid=$(lsof -ti :"$port" 2>/dev/null | head -1)
+
+	if [[ -z "$pid" ]]; then
+		error "No server running on port $port"
+		exit 1
+	fi
+
+	benchmark_server "$name" "$port" "$pid"
+}
+
+# Main
+case "${1:-all}" in
+all)
+	benchmark_all
+	;;
+lunet)
+	benchmark_single 8080 "lunet-mcp-sse"
+	;;
+single)
+	benchmark_single "${2:-8080}" "${3:-MCP Server}"
+	;;
+*)
+	echo "Usage: $0 [all|lunet|single <port> <name>]"
+	echo ""
+	echo "Commands:"
+	echo "  all              - Benchmark all implementations"
+	echo "  lunet            - Benchmark running lunet server on port 8080"
+	echo "  single <port>    - Benchmark any server on specified port"
+	echo ""
+	echo "Environment:"
+	echo "  MOCK_PORT        - Mock Tavily server port (default: 19999)"
+	echo "  CONCURRENCY      - Concurrent connections (default: 50)"
+	echo "  TOTAL_REQUESTS   - Total requests to send (default: 500)"
+	;;
+esac

--- a/scripts/lunet_bin.sh
+++ b/scripts/lunet_bin.sh
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-LUNET_DIR="${LUNET_DIR:-../lunet}"
-LUNET_REF="${LUNET_REF:-codex/httpc-libcurl}"
+LUNET_DIR="${LUNET_DIR:-./deps/lunet}"
 DO_BUILD=0
 
 while [[ $# -gt 0 ]]; do
@@ -18,21 +17,9 @@ while [[ $# -gt 0 ]]; do
 	esac
 done
 
-if [[ ! -d "$LUNET_DIR/.git" ]]; then
-	echo "ERROR: lunet repo not found at $LUNET_DIR" >&2
-	echo "Clone it first: git clone https://github.com/lua-lunet/lunet.git $LUNET_DIR" >&2
-	exit 1
-fi
-
-if ! git -C "$LUNET_DIR" rev-parse "$LUNET_REF" >/dev/null 2>&1; then
-	echo "ERROR: required lunet ref $LUNET_REF not found in $LUNET_DIR" >&2
-	echo "Run: git -C \"$LUNET_DIR\" fetch --all --tags" >&2
-	exit 1
-fi
-
-if ! git -C "$LUNET_DIR" merge-base --is-ancestor "$LUNET_REF" HEAD; then
-	echo "ERROR: lunet checkout does not include required ref $LUNET_REF in $LUNET_DIR" >&2
-	echo "Run: git -C \"$LUNET_DIR\" checkout $LUNET_REF && git -C \"$LUNET_DIR\" pull --ff-only" >&2
+if ! git -C "$LUNET_DIR" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+	echo "ERROR: lunet dependency not found at $LUNET_DIR" >&2
+	echo "Run: git submodule update --init --recursive" >&2
 	exit 1
 fi
 
@@ -46,6 +33,7 @@ if [[ -z "$RUNNER_BIN" && "$DO_BUILD" -eq 1 ]]; then
 		cd "$LUNET_DIR"
 		xmake f -m release --lunet_trace=n --lunet_verbose_trace=n -y
 		xmake build lunet-bin
+		xmake build lunet-httpc
 	)
 	RUNNER_BIN="$(find_runner)"
 fi

--- a/scripts/lunet_bin.sh
+++ b/scripts/lunet_bin.sh
@@ -33,6 +33,7 @@ if [[ -z "$RUNNER_BIN" && "$DO_BUILD" -eq 1 ]]; then
 		cd "$LUNET_DIR"
 		xmake f -m release --lunet_trace=n --lunet_verbose_trace=n -y
 		xmake build lunet-bin
+		xmake build lunet-sqlite3
 		xmake build lunet-httpc
 	)
 	RUNNER_BIN="$(find_runner)"

--- a/scripts/lunet_bin.sh
+++ b/scripts/lunet_bin.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+LUNET_DIR="${LUNET_DIR:-../lunet}"
+LUNET_VERSION="${LUNET_VERSION:-v0.2.3}"
+DO_BUILD=0
+
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+	--build)
+		DO_BUILD=1
+		shift
+		;;
+	*)
+		echo "Unknown argument: $1" >&2
+		exit 2
+		;;
+	esac
+done
+
+if [[ ! -d "$LUNET_DIR/.git" ]]; then
+	echo "ERROR: lunet repo not found at $LUNET_DIR" >&2
+	echo "Clone it first: git clone https://github.com/lua-lunet/lunet.git $LUNET_DIR" >&2
+	exit 1
+fi
+
+if ! git -C "$LUNET_DIR" rev-parse "$LUNET_VERSION" >/dev/null 2>&1; then
+	echo "ERROR: required lunet tag $LUNET_VERSION not found in $LUNET_DIR" >&2
+	echo "Run: git -C \"$LUNET_DIR\" fetch --tags" >&2
+	exit 1
+fi
+
+if ! git -C "$LUNET_DIR" merge-base --is-ancestor "$LUNET_VERSION" HEAD; then
+	echo "ERROR: lunet checkout is older than $LUNET_VERSION in $LUNET_DIR" >&2
+	echo "Run: git -C \"$LUNET_DIR\" checkout $LUNET_VERSION" >&2
+	exit 1
+fi
+
+find_runner() {
+	find "$LUNET_DIR/build" -path '*/release/lunet-run' -type f 2>/dev/null | head -1
+}
+
+RUNNER_BIN="$(find_runner)"
+if [[ -z "$RUNNER_BIN" && "$DO_BUILD" -eq 1 ]]; then
+	(
+		cd "$LUNET_DIR"
+		xmake f -m release --lunet_trace=n --lunet_verbose_trace=n -y
+		xmake build lunet-bin
+	)
+	RUNNER_BIN="$(find_runner)"
+fi
+
+if [[ -z "$RUNNER_BIN" ]]; then
+	echo "ERROR: lunet-run not found under $LUNET_DIR/build" >&2
+	echo "Run: (cd \"$LUNET_DIR\" && xmake f -m release --lunet_trace=n --lunet_verbose_trace=n -y && xmake build lunet-bin)" >&2
+	exit 1
+fi
+
+echo "$RUNNER_BIN"

--- a/scripts/lunet_bin.sh
+++ b/scripts/lunet_bin.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 LUNET_DIR="${LUNET_DIR:-../lunet}"
-LUNET_VERSION="${LUNET_VERSION:-v0.2.3}"
+LUNET_REF="${LUNET_REF:-codex/httpc-libcurl}"
 DO_BUILD=0
 
 while [[ $# -gt 0 ]]; do
@@ -24,15 +24,15 @@ if [[ ! -d "$LUNET_DIR/.git" ]]; then
 	exit 1
 fi
 
-if ! git -C "$LUNET_DIR" rev-parse "$LUNET_VERSION" >/dev/null 2>&1; then
-	echo "ERROR: required lunet tag $LUNET_VERSION not found in $LUNET_DIR" >&2
-	echo "Run: git -C \"$LUNET_DIR\" fetch --tags" >&2
+if ! git -C "$LUNET_DIR" rev-parse "$LUNET_REF" >/dev/null 2>&1; then
+	echo "ERROR: required lunet ref $LUNET_REF not found in $LUNET_DIR" >&2
+	echo "Run: git -C \"$LUNET_DIR\" fetch --all --tags" >&2
 	exit 1
 fi
 
-if ! git -C "$LUNET_DIR" merge-base --is-ancestor "$LUNET_VERSION" HEAD; then
-	echo "ERROR: lunet checkout is older than $LUNET_VERSION in $LUNET_DIR" >&2
-	echo "Run: git -C \"$LUNET_DIR\" checkout $LUNET_VERSION" >&2
+if ! git -C "$LUNET_DIR" merge-base --is-ancestor "$LUNET_REF" HEAD; then
+	echo "ERROR: lunet checkout does not include required ref $LUNET_REF in $LUNET_DIR" >&2
+	echo "Run: git -C \"$LUNET_DIR\" checkout $LUNET_REF && git -C \"$LUNET_DIR\" pull --ff-only" >&2
 	exit 1
 fi
 

--- a/stuff.html
+++ b/stuff.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <style>
+    .tiles {
+      display: flex;
+      gap: 1rem;
+      font-family: system-ui, sans-serif;
+    }
+    .tile {
+      padding: 1rem 1.2rem;
+      border-radius: 8px;
+      color: #111;
+      font-weight: 600;
+      min-width: 140px;
+      text-align: center;
+      box-shadow: 0 2px 4px rgba(0,0,0,0.12);
+    }
+
+    /* Strong alert */
+    .tile-red {
+      background: #FF4D4D;
+      color: #fff;
+    }
+
+    /* Attention without panic */
+    .tile-amber {
+      background: #FFA500;
+      color: #111;
+    }
+
+    /* High‑visibility but friendly */
+    .tile-yellow {
+      background: #FFEB3B;
+      color: #111;
+    }
+
+    /* Brand‑safe highlight */
+    .tile-blue {
+      background: #2196F3;
+      color: #fff;
+    }
+
+    /* Subtle but focused */
+    .tile-border {
+      background: #FFFFFF;
+      border: 3px solid #FFA500;
+    }
+  </style>
+</head>
+<body>
+  <div class="tiles">
+    <div class="tile tile-red">Urgent / Error</div>
+    <div class="tile tile-amber">Needs Attention</div>
+    <div class="tile tile-yellow">Highlighted</div>
+    <div class="tile tile-blue">Primary Action</div>
+    <div class="tile tile-border">Subtle Highlight</div>
+  </div>
+</body>
+</html>

--- a/test/bench_memory.lua
+++ b/test/bench_memory.lua
@@ -6,7 +6,7 @@
 -- then applies load and measures peak memory.
 --
 -- Usage:
---   ./lunet/build/<platform>/<arch>/release/lunet-run test/bench_memory.lua
+--   ./deps/lunet/build/<platform>/<arch>/release/lunet-run test/bench_memory.lua
 --
 -- Environment:
 --   BENCH_PORT      - Server port (default 8081, different to avoid conflicts)

--- a/test/bench_memory.lua
+++ b/test/bench_memory.lua
@@ -6,7 +6,7 @@
 -- then applies load and measures peak memory.
 --
 -- Usage:
---   ./lunet/build/lunet test/bench_memory.lua
+--   ./lunet/build/<platform>/<arch>/release/lunet-run test/bench_memory.lua
 --
 -- Environment:
 --   BENCH_PORT      - Server port (default 8081, different to avoid conflicts)

--- a/test/stress_mcp.lua
+++ b/test/stress_mcp.lua
@@ -9,10 +9,10 @@
 --
 -- Usage:
 --   # Start server first:
---   ./lunet/build/<platform>/<arch>/release/lunet-run app/main.lua &
+--   ./deps/lunet/build/<platform>/<arch>/release/lunet-run app/main.lua &
 --   
 --   # Then run stress test:
---   ./lunet/build/<platform>/<arch>/release/lunet-run test/stress_mcp.lua
+--   ./deps/lunet/build/<platform>/<arch>/release/lunet-run test/stress_mcp.lua
 --
 -- Environment:
 --   STRESS_CLIENTS   - Number of concurrent clients (default 20)
@@ -258,7 +258,7 @@ lunet.spawn(function()
     local check_resp, check_err = http_request("GET", "/")
     if not check_resp then
         print("[STRESS] FATAL: Server not running at " .. HOST .. ":" .. PORT)
-        print("[STRESS] Start the server first: ./lunet/build/<platform>/<arch>/release/lunet-run app/main.lua")
+        print("[STRESS] Start the server first: ./deps/lunet/build/<platform>/<arch>/release/lunet-run app/main.lua")
         os.exit(1)
     end
 

--- a/test/stress_mcp.lua
+++ b/test/stress_mcp.lua
@@ -9,10 +9,10 @@
 --
 -- Usage:
 --   # Start server first:
---   ./lunet/build/lunet app/main.lua &
+--   ./lunet/build/<platform>/<arch>/release/lunet-run app/main.lua &
 --   
 --   # Then run stress test:
---   ./lunet/build/lunet test/stress_mcp.lua
+--   ./lunet/build/<platform>/<arch>/release/lunet-run test/stress_mcp.lua
 --
 -- Environment:
 --   STRESS_CLIENTS   - Number of concurrent clients (default 20)
@@ -258,7 +258,7 @@ lunet.spawn(function()
     local check_resp, check_err = http_request("GET", "/")
     if not check_resp then
         print("[STRESS] FATAL: Server not running at " .. HOST .. ":" .. PORT)
-        print("[STRESS] Start the server first: ./lunet/build/lunet app/main.lua")
+        print("[STRESS] Start the server first: ./lunet/build/<platform>/<arch>/release/lunet-run app/main.lua")
         os.exit(1)
     end
 


### PR DESCRIPTION
## What
- Switch Lunet dependency to repo-local git submodule at `deps/lunet` (no more `../lunet` cross-writes)
- Update build/run tooling (`Makefile`, `scripts/lunet_bin.sh`, benchmark helper) to build via xmake from `deps/lunet`
- Prefer native outbound HTTPS via `require("lunet.httpc")` (libcurl) for Tavily calls; keep curl-subprocess fallback
- Update CI workflow to build Lunet from the submodule (`submodules: recursive`) and package from `deps/lunet/build/...`

## Lunet dependency
- `deps/lunet` now points at Lunet `main` commit that includes the merged HTTPS client:
  - lunet commit: `ef89d0d` ("Add lunet.httpc outbound HTTPS client (libcurl) (#91)")

## Verification (local)
- `make build`
- Smoke: run `lunet.httpc` against `https://example.com/` -> status 200
- `MCP_TRACE=debug make run` + `./test_tavily.sh` -> server log shows `Using lunet.httpc for HTTPS`
