### PR TITLE
feat: xmake build/run workflow (closes #6)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ lua_modules/
 # OS files
 .DS_Store
 Thumbs.db
+.xmake/

--- a/Makefile
+++ b/Makefile
@@ -1,63 +1,44 @@
-# lunet-mcp-sse Makefile
+# lunet-mcp-sse Makefile (compatibility wrapper)
 #
-# A demo MCP-SSE server for Tavily search using the Lunet framework.
-# Follows Lunet xmake integration (docs/XMAKE_INTEGRATION.md).
+# Prefer xmake directly: xmake lunet-build && xmake lunet-run
+# This Makefile delegates to xmake tasks for convenience.
 
-LUNET_DIR ?= ./deps/lunet
-LUNET_BIN_HELPER := ./scripts/lunet_bin.sh
-
-# Default timeout for commands (seconds)
-TIMEOUT := 10
-
-# Detect timeout command (GNU coreutils vs BSD)
-TIMEOUT_CMD := $(shell command -v gtimeout 2>/dev/null || command -v timeout 2>/dev/null || echo "")
-
-.PHONY: all build check-lunet-version run run-info run-debug run-trace run-port test stress bench bench-heavy bench-shell stress-shell clean clean-all help
+.PHONY: all build run run-info run-debug run-trace run-port test stress bench bench-heavy bench-shell stress-shell smoke clean clean-all help
 
 all: help
 
-check-lunet-version:
-	@LUNET_DIR="$(LUNET_DIR)" $(LUNET_BIN_HELPER) >/dev/null
+build:
+	@xmake lunet-build
 
-# Build lunet via official xmake flow
-build: check-lunet-version
-	@LUNET_DIR="$(LUNET_DIR)" $(LUNET_BIN_HELPER) --build >/dev/null
-	@LUNET_BIN=$$(LUNET_DIR="$(LUNET_DIR)" $(LUNET_BIN_HELPER)); \
-	echo "Build complete. Lunet runner: $$LUNET_BIN"
-
-# Run the MCP server (no tracing)
 run: build
-	@LUNET_BIN=$$(LUNET_DIR="$(LUNET_DIR)" $(LUNET_BIN_HELPER)); \
-	"$$LUNET_BIN" app/main.lua
+	@xmake lunet-run
 
-# Run with info-level tracing
 run-info: build
-	@LUNET_BIN=$$(LUNET_DIR="$(LUNET_DIR)" $(LUNET_BIN_HELPER)); \
-	MCP_TRACE=info "$$LUNET_BIN" app/main.lua
+	@xmake lunet-run --trace=info
 
-# Run with debug-level tracing
 run-debug: build
-	@LUNET_BIN=$$(LUNET_DIR="$(LUNET_DIR)" $(LUNET_BIN_HELPER)); \
-	MCP_TRACE=debug "$$LUNET_BIN" app/main.lua
+	@xmake lunet-run --trace=debug
 
-# Run with full tracing
 run-trace: build
-	@LUNET_BIN=$$(LUNET_DIR="$(LUNET_DIR)" $(LUNET_BIN_HELPER)); \
-	MCP_TRACE=trace "$$LUNET_BIN" app/main.lua
+	@xmake lunet-run --trace=trace
 
-# Run with custom port
 run-port: build
-	@LUNET_BIN=$$(LUNET_DIR="$(LUNET_DIR)" $(LUNET_BIN_HELPER)); \
-	PORT=$(PORT) "$$LUNET_BIN" app/main.lua
+	@xmake lunet-run --port=$(PORT)
 
-# Test the server (must be running)
 test:
-	@echo "Testing server info endpoint..."
-	@curl -s --max-time 5 http://localhost:8080/ || echo "ERROR: Server not responding"
-	@echo ""
-	@echo "Testing SSE endpoint (3 seconds)..."
-	@curl -sN --max-time 3 http://localhost:8080/sse || true
-	@echo ""
+	@xmake lunet-test
+
+stress: build
+	@xmake lunet-stress
+
+bench: build
+	@xmake lunet-bench
+
+bench-heavy: build
+	@xmake lunet-bench-heavy
+
+smoke: build
+	@xmake lunet-smoke
 
 # Shell-based benchmark (server must be running)
 bench-shell:
@@ -72,80 +53,38 @@ stress-shell:
 	@echo ""
 	@echo "Done"
 
-# Lua stress test (server must be running)
-stress: build
-ifneq ($(TIMEOUT_CMD),)
-	@LUNET_BIN=$$(LUNET_DIR="$(LUNET_DIR)" $(LUNET_BIN_HELPER)); \
-	$(TIMEOUT_CMD) 60 "$$LUNET_BIN" test/stress_mcp.lua || echo "Stress test timed out or failed"
-else
-	@echo "WARNING: No timeout command available, running without timeout"
-	@LUNET_BIN=$$(LUNET_DIR="$(LUNET_DIR)" $(LUNET_BIN_HELPER)); \
-	"$$LUNET_BIN" test/stress_mcp.lua
-endif
-
-# Memory benchmark (starts its own server)
-bench: build
-ifneq ($(TIMEOUT_CMD),)
-	@LUNET_BIN=$$(LUNET_DIR="$(LUNET_DIR)" $(LUNET_BIN_HELPER)); \
-	$(TIMEOUT_CMD) 30 "$$LUNET_BIN" test/bench_memory.lua || echo "Benchmark timed out or failed"
-else
-	@echo "WARNING: No timeout command available, running without timeout"
-	@LUNET_BIN=$$(LUNET_DIR="$(LUNET_DIR)" $(LUNET_BIN_HELPER)); \
-	"$$LUNET_BIN" test/bench_memory.lua
-endif
-
-# Run benchmark with more clients
-bench-heavy: build
-ifneq ($(TIMEOUT_CMD),)
-	@LUNET_BIN=$$(LUNET_DIR="$(LUNET_DIR)" $(LUNET_BIN_HELPER)); \
-	BENCH_CLIENTS=100 BENCH_REQUESTS=50 $(TIMEOUT_CMD) 60 "$$LUNET_BIN" test/bench_memory.lua || echo "Heavy benchmark timed out or failed"
-else
-	@LUNET_BIN=$$(LUNET_DIR="$(LUNET_DIR)" $(LUNET_BIN_HELPER)); \
-	BENCH_CLIENTS=100 BENCH_REQUESTS=50 "$$LUNET_BIN" test/bench_memory.lua
-endif
-
-# Clean build artifacts
 clean:
 	rm -rf .tmp/*.log
 	@echo "Cleaned temporary files"
 
-# Deep clean (including lunet build)
 clean-all: clean
-	cd "$(LUNET_DIR)" && xmake clean 2>/dev/null || true
+	cd deps/lunet && xmake clean 2>/dev/null || true
 	@echo "Cleaned all build artifacts"
 
-# Show help
 help:
-	@echo "lunet-mcp-sse"
-	@echo "============="
+	@echo "lunet-mcp-sse (make -> xmake wrapper)"
+	@echo "======================================"
 	@echo ""
-	@echo "A demo MCP-SSE server exposing Tavily search via the Lunet framework."
+	@echo "Prefer using xmake directly (see xmake.lua):"
+	@echo "  xmake lunet-build              Build Lunet runtime + modules"
+	@echo "  xmake lunet-run [--trace=LVL]  Start the MCP server"
+	@echo "  xmake lunet-smoke              Run httpc smoke test"
 	@echo ""
-	@echo "Usage:"
-	@echo "  make build       - Build lunet-run via xmake (deps/lunet)"
-	@echo "  make run         - Start the MCP server (port 8080)"
-	@echo "  make run-info    - Start with info-level tracing"
-	@echo "  make run-debug   - Start with debug-level tracing"
-	@echo "  make run-trace   - Start with full tracing"
-	@echo "  make run-port PORT=9000 - Start on custom port"
-	@echo "  make test        - Test endpoints (server must be running)"
-	@echo "  make bench-shell - Run shell-based benchmark"
-	@echo "  make stress-shell - Run shell-based stress test"
-	@echo "  make stress      - Run Lua stress test (server must be running)"
-	@echo "  make bench       - Run Lua memory benchmark"
-	@echo "  make clean       - Clean temporary files"
+	@echo "make targets (delegating to xmake):"
+	@echo "  make build       - xmake lunet-build"
+	@echo "  make run         - xmake lunet-run"
+	@echo "  make run-info    - xmake lunet-run --trace=info"
+	@echo "  make run-debug   - xmake lunet-run --trace=debug"
+	@echo "  make run-trace   - xmake lunet-run --trace=trace"
+	@echo "  make test        - xmake lunet-test"
+	@echo "  make stress      - xmake lunet-stress"
+	@echo "  make bench       - xmake lunet-bench"
+	@echo "  make smoke       - xmake lunet-smoke"
+	@echo "  make clean       - Clean temp files"
 	@echo "  make clean-all   - Clean all including lunet build"
 	@echo ""
-	@echo "Environment:"
-	@echo "  LUNET_DIR        - Lunet repo path (default: ./deps/lunet)"
-	@echo "  TAVILY_API_KEY   - Your Tavily API key (in .env file)"
-	@echo "  PORT             - Server port (default 8080)"
-	@echo "  MCP_TRACE        - Trace level: off|error|warn|info|debug|trace"
-	@echo "  MCP_TRACE_FILE   - Trace output file (default: stderr)"
-	@echo ""
 	@echo "Quick Start:"
-	@echo "  1. Create .env with TAVILY_API_KEY=your_key"
-	@echo "  2. git submodule update --init --recursive"
-	@echo "  3. make build"
-	@echo "  4. make run"
-	@echo "  5. curl http://localhost:8080/"
+	@echo "  1. git submodule update --init --recursive"
+	@echo "  2. echo 'TAVILY_API_KEY=your_key' > .env"
+	@echo "  3. make build && make run"
+	@echo "  4. curl http://localhost:8080/"

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ Search the web using Tavily AI search engine.
 
 ## Building from Source
 
-Requires [xmake](https://xmake.io/) and Lunet v0.1.2+. See [XMAKE_INTEGRATION.md](https://github.com/lua-lunet/lunet/blob/main/docs/XMAKE_INTEGRATION.md) for the canonical integration guide.
+Requires [xmake](https://xmake.io/). See [XMAKE_INTEGRATION.md](https://github.com/lua-lunet/lunet/blob/main/docs/XMAKE_INTEGRATION.md) for the canonical Lunet integration guide.
 
 ```bash
 # Clone and init submodules
@@ -228,10 +228,29 @@ git clone https://github.com/lua-lunet/lunet-mcp-sse.git
 cd lunet-mcp-sse
 git submodule update --init --recursive
 
-# Run
+# Build and run (xmake workflow)
 echo "TAVILY_API_KEY=your_key_here" > .env
+xmake lunet-build
+xmake lunet-run
+
+# Or via make (compatibility wrapper)
+make build
 make run
 ```
+
+### xmake Tasks
+
+| Task | Description |
+|------|-------------|
+| `xmake lunet-build` | Build Lunet runtime + modules from `deps/lunet` |
+| `xmake lunet-run` | Start the MCP server |
+| `xmake lunet-run --trace=debug` | Start with debug tracing |
+| `xmake lunet-run --port=9000` | Start on custom port |
+| `xmake lunet-test` | Test endpoints (server must be running) |
+| `xmake lunet-stress` | Run Lua stress test |
+| `xmake lunet-bench` | Run memory benchmark |
+| `xmake lunet-smoke` | Run httpc smoke test (HTTPS to example.com) |
+| `xmake lunet-package` | Package dist/ for release |
 
 ## Zero-Cost Tracing
 

--- a/app/main.lua
+++ b/app/main.lua
@@ -31,10 +31,12 @@ io.stderr:setvbuf('no')
 
 -- Parse -v/--verbose for startup logging
 local VERBOSE = false
-for i = 1, #arg do
-    if arg[i] == "-v" or arg[i] == "--verbose" then
-        VERBOSE = true
-        break
+if arg then
+    for i = 1, #arg do
+        if arg[i] == "-v" or arg[i] == "--verbose" then
+            VERBOSE = true
+            break
+        end
     end
 end
 

--- a/xmake.lua
+++ b/xmake.lua
@@ -1,0 +1,205 @@
+-- lunet-mcp-sse: MCP SSE server built on Lunet
+-- Build system: xmake (delegates to deps/lunet for native targets)
+--
+-- Usage:
+--   git submodule update --init --recursive
+--   xmake lunet-build
+--   xmake lunet-run
+--
+-- See also: https://github.com/lua-lunet/lunet/blob/main/docs/XMAKE_INTEGRATION.md
+
+set_project("lunet-mcp-sse")
+set_version("0.1.0")
+
+-- ============================================================================
+-- Configuration
+-- ============================================================================
+
+local lunet_dir = "deps/lunet"
+
+-- ============================================================================
+-- Helpers
+-- ============================================================================
+
+local function quote(s)
+    return "\"" .. tostring(s):gsub("\"", "\\\"") .. "\""
+end
+
+local function xmake_in_lunet(cmd)
+    os.exec("cd " .. quote(lunet_dir) .. " && " .. cmd)
+end
+
+local function runner_path(mode)
+    local name = is_host("windows") and "lunet-run.exe" or "lunet-run"
+    local matches = os.files(path.join(lunet_dir, "build/**/" .. mode .. "/" .. name))
+    if #matches == 0 then
+        raise("lunet-run not found for mode: " .. mode .. ". Run: xmake lunet-build")
+    end
+    return matches[1]
+end
+
+local function lunet_module_dir(mode)
+    local dirs = os.dirs(path.join(lunet_dir, "build/**/" .. mode .. "/lunet"))
+    if #dirs > 0 then return dirs[1] end
+    return nil
+end
+
+-- ============================================================================
+-- Tasks
+-- ============================================================================
+
+task("lunet-build")
+    set_menu {
+        usage = "xmake lunet-build",
+        description = "Build Lunet runtime + modules from deps/lunet"
+    }
+    on_run(function ()
+        local p = "-P " .. quote(lunet_dir)
+        os.runv("xmake", {"f", "-P", lunet_dir, "-m", "release", "--lunet_trace=n", "--lunet_verbose_trace=n", "-y"})
+        os.runv("xmake", {"build", "-P", lunet_dir, "lunet-bin"})
+        os.runv("xmake", {"build", "-P", lunet_dir, "lunet-sqlite3"})
+        os.runv("xmake", {"build", "-P", lunet_dir, "lunet-httpc"})
+        local runner = runner_path("release")
+        cprint("${green}Build complete.${clear} Runner: " .. runner)
+    end)
+task_end()
+
+task("lunet-run")
+    set_menu {
+        usage = "xmake lunet-run [--trace=LEVEL] [--port=PORT]",
+        description = "Start the MCP server",
+        options = {
+            {nil, "trace", "kv", nil, "MCP trace level (off/error/warn/info/debug/trace)"},
+            {nil, "port",  "kv", nil, "Server port (default 8080)"},
+        }
+    }
+    on_run(function ()
+        import("core.base.option")
+        local runner = runner_path("release")
+        local cmd = quote(runner) .. " app/main.lua"
+        local env_prefix = ""
+        if option.get("trace") then env_prefix = env_prefix .. "MCP_TRACE=" .. option.get("trace") .. " " end
+        if option.get("port") then env_prefix = env_prefix .. "PORT=" .. option.get("port") .. " " end
+        os.run(env_prefix .. cmd)
+    end)
+task_end()
+
+task("lunet-test")
+    set_menu {
+        usage = "xmake lunet-test",
+        description = "Test server endpoints (server must be running)"
+    }
+    on_run(function ()
+        print("Testing server info endpoint...")
+        os.exec("curl -s --max-time 5 http://localhost:8080/ || echo 'ERROR: Server not responding'")
+        print("")
+        print("Testing SSE endpoint (3 seconds)...")
+        os.exec("curl -sN --max-time 3 http://localhost:8080/sse || true")
+        print("")
+    end)
+task_end()
+
+task("lunet-stress")
+    set_menu {
+        usage = "xmake lunet-stress",
+        description = "Run Lua stress test (server must be running)"
+    }
+    on_run(function ()
+        local runner = runner_path("release")
+        if is_host("windows") then
+            os.execv(runner, {"test/stress_mcp.lua"})
+        else
+            os.execv("bash", {"-lc", "timeout 60 " .. quote(runner) .. " test/stress_mcp.lua || echo 'Stress test timed out or failed'"})
+        end
+    end)
+task_end()
+
+task("lunet-bench")
+    set_menu {
+        usage = "xmake lunet-bench",
+        description = "Run Lua memory benchmark"
+    }
+    on_run(function ()
+        local runner = runner_path("release")
+        if is_host("windows") then
+            os.execv(runner, {"test/bench_memory.lua"})
+        else
+            os.execv("bash", {"-lc", "timeout 30 " .. quote(runner) .. " test/bench_memory.lua || echo 'Benchmark timed out or failed'"})
+        end
+    end)
+task_end()
+
+task("lunet-bench-heavy")
+    set_menu {
+        usage = "xmake lunet-bench-heavy",
+        description = "Run Lua memory benchmark with more clients"
+    }
+    on_run(function ()
+        local runner = runner_path("release")
+        if is_host("windows") then
+            os.execv(runner, {"test/bench_memory.lua"}, {envs = {BENCH_CLIENTS = "100", BENCH_REQUESTS = "50"}})
+        else
+            os.execv("bash", {"-lc", "BENCH_CLIENTS=100 BENCH_REQUESTS=50 timeout 60 " .. quote(runner) .. " test/bench_memory.lua || echo 'Heavy benchmark timed out or failed'"})
+        end
+    end)
+task_end()
+
+task("lunet-smoke")
+    set_menu {
+        usage = "xmake lunet-smoke",
+        description = "Run httpc smoke test (HTTPS GET to example.com)"
+    }
+    on_run(function ()
+        local runner = runner_path("release")
+        os.execv(runner, {".tmp/httpc_smoke.lua"})
+    end)
+task_end()
+
+task("lunet-package")
+    set_menu {
+        usage = "xmake lunet-package",
+        description = "Package dist/ directory for release"
+    }
+    on_run(function ()
+        local runner = runner_path("release")
+        local moddir = lunet_module_dir("release")
+
+        os.mkdir("dist/bin")
+        os.mkdir("dist/lib")
+        os.mkdir("dist/app")
+        os.mkdir("dist/test")
+
+        os.cp(runner, "dist/bin/lunet" .. (is_host("windows") and ".exe" or ""))
+
+        if moddir then
+            local ext = is_host("windows") and "*.dll" or "*.so"
+            local libs = os.files(path.join(moddir, ext))
+            for _, f in ipairs(libs) do os.cp(f, "dist/lib/") end
+        end
+
+        local lunet_so = os.files(path.join(lunet_dir, "build/**/release/lunet" .. (is_host("windows") and ".dll" or ".so")))
+        if #lunet_so > 0 then os.cp(lunet_so[1], "dist/lib/") end
+
+        os.cp("app/*", "dist/app/")
+        os.cp("test/*", "dist/test/")
+        os.cp("Makefile", "dist/")
+        os.cp("README.md", "dist/")
+        if os.isfile("lunet-mcp-sse-scm-1.rockspec") then
+            os.cp("lunet-mcp-sse-scm-1.rockspec", "dist/")
+        end
+
+        if is_host("windows") then
+            os.exec("cd dist && 7z a ../lunet-mcp-sse-windows-amd64.zip .")
+        else
+            local f = io.open("dist/run.sh", "w")
+            f:write('#!/bin/bash\n')
+            f:write('SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"\n')
+            f:write('export LUA_CPATH="$SCRIPT_DIR/lib/?.so;;"\n')
+            f:write('exec "$SCRIPT_DIR/bin/lunet" "$SCRIPT_DIR/app/main.lua" "$@"\n')
+            f:close()
+            os.exec("chmod +x dist/run.sh")
+        end
+
+        cprint("${green}Package complete.${clear} Output: dist/")
+    end)
+task_end()


### PR DESCRIPTION
## Summary
Add `xmake.lua` as the primary build/run workflow for lunet-mcp-sse, per the Lunet [XMAKE_INTEGRATION.md](https://github.com/lua-lunet/lunet/blob/main/docs/XMAKE_INTEGRATION.md) guide.

Closes #6.

## What changed
- **New `xmake.lua`** with tasks: `lunet-build`, `lunet-run`, `lunet-test`, `lunet-stress`, `lunet-bench`, `lunet-bench-heavy`, `lunet-smoke`, `lunet-package`
- **Makefile** is now a thin compatibility wrapper that delegates every target to `xmake lunet-*`
- **README** updated: xmake-first workflow, task reference table, `make` shown as fallback
- **app/main.lua** fix: guard `arg` global (nil when invoked via xmake `os.run`)

## Verification
```bash
xmake lunet-build          # builds lunet-bin + sqlite3 + httpc
xmake lunet-run            # starts server (exit with Ctrl-C)
xmake lunet-smoke          # httpc smoke: status 200, body_len 528
make build && make smoke   # same via Makefile wrapper
```
