### PR TITLE
Fix Docker metadata action expression in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,7 +221,9 @@ jobs:
           tags: |
             type=sha
             type=ref,event=branch
-            type=raw,value=nightly,enable=eq(${{ github.ref }}, 'refs/heads/main')
+            type=raw,value=nightly,enable=${{ github.ref == 'refs/heads/main' }}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
 
       - name: Build and push multi-arch Docker
         uses: docker/build-push-action@v5


### PR DESCRIPTION
## Summary
Fixes the metadata enable expression syntax in the multi-arch Docker build job (`enable=${{ github.ref == 'refs/heads/main' }}`) and adds standard semver tags for releases.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lua-lunet/codesmith/lunet-mcp-sse/pr/17"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789290950&installation_model_id=428190&pr_number=17&repository=lua-lunet%2Flunet-mcp-sse&return_to=https%3A%2F%2Fgithub.com%2Flua-lunet%2Flunet-mcp-sse%2Fpull%2F17&signature=50e9887ea74889e1ecb2fdfe34b034600edcdc26ea5b0fa9d982e9997f01ff00"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->